### PR TITLE
Do not always compile docs

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -16,10 +16,19 @@ set(MATHJAX_PATH ${CONTENT_PATH}/MathJax)
 # Configure doxyfile
 configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
 
-# Add target
-add_custom_target(doc_doxygen ALL
+# Use full path to refer to the code dependencies
+list(TRANSFORM FUTSIM_EXTERNAL_HEADERS PREPEND ${FUTSIM_DIR}/ OUTPUT_VARIABLE FULL_PATH_FUTSIM_EXTERNAL_HEADERS)
+
+# Add command that generates the doxygen documentation
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/html/index.html
 	COMMAND ${CMAKE_COMMAND} -E copy_directory ${MATHJAX_PATH}/es5 ${CMAKE_CURRENT_SOURCE_DIR}/html/MathJax/es5
 	COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 	COMMENT "Generating documentation with Doxygen"
+	DEPENDS ${FULL_PATH_FUTSIM_EXTERNAL_HEADERS}
 	VERBATIM)
+
+# Add custom target
+add_custom_target(doc_doxygen ALL
+	DEPENDS ${FUTSIM_DIR}/doc/html/index.html
+)


### PR DESCRIPTION
Only compile when external headers are modified.

Resolves #49.