### PR TITLE
Use json utils

### DIFF
--- a/include/CPerson.h
+++ b/include/CPerson.h
@@ -43,7 +43,7 @@ protected:
 	/**
 	 * @copydoc IJsonable::ToJSON
 	*/
-	json JSON() const noexcept override;
+	void JSON( json& aJSON ) const noexcept override;
 
 public:
 	//! Retrieves the \copybrief mFirstName

--- a/include/IJsonable.h
+++ b/include/IJsonable.h
@@ -19,15 +19,15 @@ public:
 	virtual ~IJsonable() = default;
 
 	/**
-	 * @brief Returns the class represented as JSON.
+	 * @brief Adds the class to JSON object.
 	 */
-	json ToJSON() const noexcept;
+	void ToJSON( json& aJSON ) const noexcept;
 
 private:
 	/**
 	 * @copydoc ToJSON
 	*/
-	virtual json JSON() const noexcept = 0;
+	virtual void JSON( json& aJSON ) const noexcept = 0;
 };
 
 } // futsim namespace

--- a/include/IJsonableTypes.h
+++ b/include/IJsonableTypes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 /**
  * @brief Types defined for \ref IJsonable.

--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -29,53 +29,122 @@ template<typename T> concept is_jsonable = has_json_key<T> && has_to_json<T>;
 //! Concept for a type that cannot be converted to JSON.
 template<typename T> concept is_not_jsonable = ( has_json_key<T> == false || has_to_json<T> == false );
 
+/**
+ * @brief Helper function to construct a jsonable class from a JSON object.
+ * @param aJSON JSON object.
+ * @param aArgs Extra arguments to be forwarded to the JSON constructor.
+*/
 template<is_json_constructible T, is_json_type JsonType>
 inline T ValueFromJSON( const JsonType& aJSON, auto&&... aArgs );
 
+/**
+ * @brief Helper function to construct a non-jsonable type from a JSON object.
+ * @param aJSON JSON object.
+*/
 template<is_not_json_constructible T, is_json_type JsonType>
 inline T ValueFromJSON( const JsonType& aJSON );
 
+/**
+ * @brief Helper function to construct a jsonable class under a key in a JSON object.
+ * @param aJSON JSON object.
+ * @param aArgs Extra arguments to be forwarded to the JSON constructor.
+ * @param aKeyName Name of the key to search.
+*/
 template<is_json_constructible T, is_json_type JsonType>
 inline T ValueFromRequiredJSONKey( const JsonType& aJSON, auto&&... aArgs, const std::string_view aKeyName = T::JSON_KEY );
 
+/**
+ * @brief Helper function to construct a non-jsonable type under a key in a JSON object.
+ * @param aJSON JSON object.
+ * @param aKeyName Name of the key to search.
+*/
 template<is_not_json_constructible T, is_json_type JsonType>
 inline T ValueFromRequiredJSONKey( const JsonType& aJSON, const std::string_view aKeyName );
 
+/**
+ * @brief Helper function to construct a jsonable class under an optional key in a JSON object.
+ * @param aJSON JSON object.
+ * @param aArgs Extra arguments to be forwarded to the JSON constructor.
+ * @param aKeyName Name of the key to search.
+ * @param aDefaultValue Default value is key is not found.
+*/
 template<is_json_constructible T, is_json_type JsonType>
 inline T ValueFromOptionalJSONKey( const JsonType& aJSON, auto&&... aArgs, const std::string_view aKeyName = T::JSON_KEY, const T& aDefaultValue = T{} );
 
+/**
+ * @brief Helper function to construct a non-jsonable type under an optional key in a JSON object.
+ * @param aJSON JSON object.
+ * @param aKeyName Name of the key to search.
+ * @param aDefaultValue Default value is key is not found.
+*/
 template<is_not_json_constructible T, is_json_type JsonType>
 inline T ValueFromOptionalJSONKey( const JsonType& aJSON, const std::string_view aKeyName, const T& aDefaultValue = T{} );
 
+/**
+ * @brief Helper function to construct a jsonable class from a JSON string.
+ * @param aJSONString JSON string.
+ * @param aArgs Extra arguments to be forwarded to the JSON constructor.
+*/
 template<is_json_constructible T>
 inline T ValueFromJSONString( const std::string_view& aJSONString, auto&&... aArgs );
 
+/**
+ * @brief Helper function to construct a non-jsonable type from a JSON string.
+ * @param aJSONString JSON string.
+*/
 template<is_not_json_constructible T>
 inline T ValueFromJSONString( const std::string_view& aJSONString );
 
+/**
+ * @brief Helper function to construct a jsonable class from a key in a JSON string.
+ * @param aJSONString JSON string.
+ * @param aArgs Extra arguments to be forwarded to the JSON constructor.
+ * @param aKeyName Name of the key to search.
+*/
 template<is_json_constructible T>
 inline T ValueFromJSONKeyString( const std::string_view& aJSONString, auto&&... aArgs, const std::string_view aKeyName = T::JSON_KEY );
 
+/**
+ * @brief Helper function to construct a non-jsonable type from a key in a JSON string.
+ * @param aJSONString JSON string.
+ * @param aKeyName Name of the key to search.
+*/
 template<is_not_json_constructible T>
 inline T ValueFromJSONKeyString( const std::string_view& aJSONString, const std::string_view aKeyName );
 
+/**
+ * @brief Helper function to add a jsonable object to a JSON object.
+ * @param aJSON JSON object.
+ * @param aObject Value to add.
+*/
 template<is_jsonable T, is_json_type JsonType>
 inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept;
 
+/**
+ * @brief Helper function to add a non-jsonable type to a JSON object.
+ * @param aJSON JSON object.
+ * @param aObject Value to add.
+*/
 template<is_not_jsonable T, is_json_type JsonType>
 inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept;
 
+/**
+ * @brief Helper function to add a jsonable class to a JSON object.
+ * @param aJSON JSON object.
+ * @param aObject Value to add.
+ * @param aKeyName Name of the key under which to add it.
+*/
 template<is_jsonable T, is_json_type JsonType>
 inline JsonType& AddToJSONKey( JsonType& aJSON, const T& aObject, const std::string_view aKeyName = T::JSON_KEY ) noexcept;
 
+/**
+ * @brief Helper function to add a non-jsonable type to a JSON object.
+ * @param aJSON JSON object.
+ * @param aObject Value to add.
+ * @param aKeyName Name of the key under which to add it.
+*/
 template<is_not_jsonable T, is_json_type JsonType>
 inline JsonType& AddToJSONKey( JsonType& aJSON, const T& aObject, const std::string_view aKeyName ) noexcept;
-
-
-
-
-
-
 
 template<is_json_constructible T, is_json_type JsonType>
 inline T ValueFromJSON( const JsonType& aJSON, auto&&... aArgs )

--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -213,12 +213,14 @@ inline T ValueFromJSONKeyString( const std::string_view& aJSONString, const std:
 template<is_jsonable T, is_json_type JsonType>
 inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject, auto&&... aArgs ) noexcept
 {
-	return aJSON = aObject.ToJSON( std::forward<decltype( aArgs )>( aArgs )... );
+	aJSON.push_back( aObject.ToJSON( std::forward<decltype( aArgs )>( aArgs )... ) );
+	return aJSON;
 }
 
 template<is_not_jsonable T, is_json_type JsonType>
 inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept
 {
+	aJSON.push_back( aObject );
 	return aJSON = aObject;
 }
 

--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -116,9 +116,10 @@ inline T ValueFromJSONKeyString( const std::string_view& aJSONString, const std:
  * @brief Helper function to add a jsonable object to a JSON object.
  * @param aJSON JSON object.
  * @param aObject Value to add.
+ * @param aArgs Arguments to be forwarded to the ToJSON method.
 */
 template<is_jsonable T, is_json_type JsonType>
-inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept;
+inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject, auto&&... aArgs ) noexcept;
 
 /**
  * @brief Helper function to add a non-jsonable type to a JSON object.
@@ -133,9 +134,10 @@ inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept;
  * @param aJSON JSON object.
  * @param aObject Value to add.
  * @param aKeyName Name of the key under which to add it.
+ * @param aArgs Arguments to be forwarded to the ToJSON method.
 */
 template<is_jsonable T, is_json_type JsonType>
-inline JsonType& AddToJSONKey( JsonType& aJSON, const T& aObject, const std::string_view aKeyName = T::JSON_KEY ) noexcept;
+inline JsonType& AddToJSONKey( JsonType& aJSON, const T& aObject, auto&&... aArgs, const std::string_view aKeyName = T::JSON_KEY ) noexcept;
 
 /**
  * @brief Helper function to add a non-jsonable type to a JSON object.
@@ -209,9 +211,9 @@ inline T ValueFromJSONKeyString( const std::string_view& aJSONString, const std:
 }
 
 template<is_jsonable T, is_json_type JsonType>
-inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept
+inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject, auto&&... aArgs ) noexcept
 {
-	return aJSON = aObject.ToJSON();
+	return aJSON = aObject.ToJSON( std::forward<decltype( aArgs )>( aArgs )... );
 }
 
 template<is_not_jsonable T, is_json_type JsonType>
@@ -221,9 +223,9 @@ inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept
 }
 
 template<is_jsonable T, is_json_type JsonType>
-inline JsonType& AddToJSONKey( JsonType& aJSON, const T& aObject, const std::string_view aKeyName ) noexcept
+inline JsonType& AddToJSONKey( JsonType& aJSON, const T& aObject, auto&&... aArgs, const std::string_view aKeyName ) noexcept
 {
-	return AddToJSON( aJSON[ aKeyName ], aObject );
+	return AddToJSON( aJSON[ aKeyName ], aObject, std::forward<decltype( aArgs )>( aArgs )... );
 }
 
 template<is_not_jsonable T, is_json_type JsonType>

--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -42,6 +42,15 @@ inline T ValueFromOptionalJSONKey( const JsonType& aJSON, const std::string_view
 template<is_json_constructible T, is_json_type JsonType>
 inline T ValueFromJSON( const JsonType& aJSON, auto&&... aArgs );
 
+/**
+ * @brief Helper function to construct a jsonable class from a string JSON node.
+ * @details The class requires to be constructible from a json type and any other set of arguments.
+ * @param aJSONString JSON string.
+ * @param aArgs Extra arguments to be forwarded to the JSON constructor.
+*/
+template<is_json_constructible T>
+inline T ValueFromJSONString( const std::string_view& aJSONString, auto&&... aArgs );
+
 template<typename T, is_json_type JsonType>
 inline T ValueFromRequiredJSONKey( const JsonType& aJSON, const std::string_view aKeyName )
 {
@@ -59,6 +68,12 @@ template<is_json_constructible T, is_json_type JsonType>
 inline T ValueFromJSON( const JsonType& aJSON, auto&&... aArgs )
 {
 	return T{ aJSON.at( T::JSON_KEY ), std::forward<decltype( aArgs )>( aArgs )... };
+}
+
+template<is_json_constructible T>
+inline T ValueFromJSONString( const std::string_view& aJSONString, auto&&... aArgs )
+{
+	return ValueFromJSON<T>( nlohmann::json::parse( aJSONString ), std::forward<decltype( aArgs )>( aArgs )... );
 }
 
 } //futsim namespace

--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -11,9 +11,11 @@ template<typename T> concept is_json_type = std::convertible_to <T, nlohmann::js
 //! Concept for a type that has a JSON_KEY member.
 template<typename T> concept has_json_key = requires { T::JSON_KEY; };
 
-//! Concept for a type that must have a JSON_KEY member.
-template<typename T> concept is_json_constructible = std::is_constructible_v<T, nlohmann::json>&&
-has_json_key<T>;
+//! Concept for a type that can be constructed from a JSON object.
+template<typename T> concept is_json_constructible = std::is_constructible_v<T, nlohmann::json>&& has_json_key<T>;
+
+//! Concept for a type that cannot be constructed from a JSON object.
+template<typename T> concept is_not_json_constructible = std::is_constructible_v<T, nlohmann::json> == false || has_json_key<T> == false;
 
 //! Concept for a type that has a ToJson method.
 template<typename T> concept has_to_json = requires ( T aT )
@@ -27,77 +29,90 @@ template<typename T> concept is_jsonable = has_json_key<T> && has_to_json<T>;
 //! Concept for a type that cannot be converted to JSON.
 template<typename T> concept is_not_jsonable = ( has_json_key<T> == false || has_to_json<T> == false );
 
-/**
- * @brief Helper function to get a value from a certain key in a JSON array.
- * @param aJSON JSON object.
- * @param aKeyName Name of the key to search.
-*/
-template<typename T, is_json_type JsonType>
-inline T ValueFromRequiredJSONKey( const JsonType& aJSON, const std::string_view aKeyName );
-
-/**
- * @brief Helper function to get a value from a certain optional key in a JSON array.
- * @details Returns the default value if the key is not found.
- * @param aJSON JSON object.
- * @param aKeyName Name of the key to search.
- * @param aDefault Value to return if key is not found.
-*/
-template<typename T, is_json_type JsonType>
-inline T ValueFromOptionalJSONKey( const JsonType& aJSON, const std::string_view aKeyName, const T& aDefault = T{} );
-
-/**
- * @brief Helper function to construct a jsonable class from a JSON node.
- * @details The class requires to be constructible from a json type and any other set of arguments.
- * @param aJSON JSON object.
- * @param aArgs Extra arguments to be forwarded to the JSON constructor.
-*/
 template<is_json_constructible T, is_json_type JsonType>
 inline T ValueFromJSON( const JsonType& aJSON, auto&&... aArgs );
 
-/**
- * @brief Helper function to construct a jsonable class from a string JSON node.
- * @details The class requires to be constructible from a json type and any other set of arguments.
- * @param aJSONString JSON string.
- * @param aArgs Extra arguments to be forwarded to the JSON constructor.
-*/
+template<is_not_json_constructible T, is_json_type JsonType>
+inline T ValueFromJSON( const JsonType& aJSON );
+
+template<is_json_constructible T, is_json_type JsonType>
+inline T ValueFromRequiredJSONKey( const JsonType& aJSON, auto&&... aArgs, const std::string_view aKeyName = T::JSON_KEY );
+
+template<is_not_json_constructible T, is_json_type JsonType>
+inline T ValueFromRequiredJSONKey( const JsonType& aJSON, const std::string_view aKeyName );
+
+template<is_json_constructible T, is_json_type JsonType>
+inline T ValueFromOptionalJSONKey( const JsonType& aJSON, auto&&... aArgs, const std::string_view aKeyName = T::JSON_KEY, const T& aDefaultValue = T{} );
+
+template<is_not_json_constructible T, is_json_type JsonType>
+inline T ValueFromOptionalJSONKey( const JsonType& aJSON, const std::string_view aKeyName, const T& aDefaultValue = T{} );
+
 template<is_json_constructible T>
 inline T ValueFromJSONString( const std::string_view& aJSONString, auto&&... aArgs );
 
-/**
- * @brief Helper function to add a jsonable object to a JSON object.
- * @param aJSON JSON object.
- * @param aObject Value to add.
- * @param aKeyName Name of the key.
-*/
+template<is_not_json_constructible T>
+inline T ValueFromJSONString( const std::string_view& aJSONString );
+
+template<is_json_constructible T>
+inline T ValueFromJSONKeyString( const std::string_view& aJSONString, auto&&... aArgs, const std::string_view aKeyName = T::JSON_KEY );
+
+template<is_not_json_constructible T>
+inline T ValueFromJSONKeyString( const std::string_view& aJSONString, const std::string_view aKeyName );
+
 template<is_jsonable T, is_json_type JsonType>
-inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject, const std::string_view aKeyName = T::JSON_KEY ) noexcept;
+inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept;
 
-/**
- * @brief Helper function to add a value to a key in a JSON object.
- * @param aJSON JSON object.
- * @param aObject Value to add.
- * @param aKeyName Name of the key.
-*/
 template<is_not_jsonable T, is_json_type JsonType>
-inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject, const std::string_view aKeyName ) noexcept;
+inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept;
 
-template<typename T, is_json_type JsonType>
-inline T ValueFromRequiredJSONKey( const JsonType& aJSON, const std::string_view aKeyName )
-{
-	return aJSON.at( aKeyName ).template get<T>();
-}
+template<is_jsonable T, is_json_type JsonType>
+inline JsonType& AddToJSONKey( JsonType& aJSON, const T& aObject, const std::string_view aKeyName = T::JSON_KEY ) noexcept;
 
-template<typename T, is_json_type JsonType>
-inline T ValueFromOptionalJSONKey( const JsonType& aJSON, const std::string_view aKeyName, const T& aDefault )
-{
-	const auto& found = aJSON.find( aKeyName );
-	return found != aJSON.cend() ? ( *found ).template get<T>() : aDefault;
-}
+template<is_not_jsonable T, is_json_type JsonType>
+inline JsonType& AddToJSONKey( JsonType& aJSON, const T& aObject, const std::string_view aKeyName ) noexcept;
+
+
+
+
+
+
 
 template<is_json_constructible T, is_json_type JsonType>
 inline T ValueFromJSON( const JsonType& aJSON, auto&&... aArgs )
 {
-	return T{ aJSON.at( T::JSON_KEY ), std::forward<decltype( aArgs )>( aArgs )... };
+	return T{ aJSON, std::forward<decltype( aArgs )>( aArgs )... };
+}
+
+template<is_not_json_constructible T, is_json_type JsonType>
+inline T ValueFromJSON( const JsonType& aJSON )
+{
+	return aJSON.template get<T>();
+}
+
+template<is_json_constructible T, is_json_type JsonType>
+inline T ValueFromRequiredJSONKey( const JsonType& aJSON, auto&&... aArgs, const std::string_view aKeyName )
+{
+	return ValueFromJSON<T>( aJSON.at( aKeyName ), std::forward<decltype( aArgs )>( aArgs )... );
+}
+
+template<is_not_json_constructible T, is_json_type JsonType>
+inline T ValueFromRequiredJSONKey( const JsonType& aJSON, const std::string_view aKeyName )
+{
+	return ValueFromJSON<T>( aJSON.at( aKeyName ) );
+}
+
+template<is_json_constructible T, is_json_type JsonType>
+inline T ValueFromOptionalJSONKey( const JsonType& aJSON, auto&&... aArgs, const std::string_view aKeyName, const T& aDefaultValue )
+{
+	const auto& found = aJSON.find( aKeyName );
+	return found != aJSON.cend() ? ValueFromJSON<T>( *found, std::forward<decltype( aArgs )>( aArgs )... ) : aDefaultValue;
+}
+
+template<is_not_json_constructible T, is_json_type JsonType>
+inline T ValueFromOptionalJSONKey( const JsonType& aJSON, const std::string_view aKeyName, const T& aDefaultValue )
+{
+	const auto& found = aJSON.find( aKeyName );
+	return found != aJSON.cend() ? ValueFromJSON<T>( *found ) : aDefaultValue;
 }
 
 template<is_json_constructible T>
@@ -106,17 +121,46 @@ inline T ValueFromJSONString( const std::string_view& aJSONString, auto&&... aAr
 	return ValueFromJSON<T>( nlohmann::json::parse( aJSONString ), std::forward<decltype( aArgs )>( aArgs )... );
 }
 
-template<is_jsonable T, is_json_type JsonType>
-inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject, const std::string_view aKeyName ) noexcept
+template<is_not_json_constructible T>
+inline T ValueFromJSONString( const std::string_view& aJSONString )
 {
-	return AddToJSON( aJSON, aObject.ToJSON(), aKeyName );
+	return ValueFromJSON<T>( nlohmann::json::parse( aJSONString ) );
+}
+
+template<is_json_constructible T>
+inline T ValueFromJSONKeyString( const std::string_view& aJSONString, auto&&... aArgs, const std::string_view aKeyName )
+{
+	return ValueFromRequiredJSONKey<T>( nlohmann::json::parse( aJSONString ), std::forward<decltype( aArgs )>( aArgs )..., aKeyName );
+}
+
+template<is_not_json_constructible T>
+inline T ValueFromJSONKeyString( const std::string_view& aJSONString, const std::string_view aKeyName )
+{
+	return ValueFromRequiredJSONKey<T>( nlohmann::json::parse( aJSONString ), aKeyName );
+}
+
+template<is_jsonable T, is_json_type JsonType>
+inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept
+{
+	return aJSON = aObject.ToJSON();
 }
 
 template<is_not_jsonable T, is_json_type JsonType>
-inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject, const std::string_view aKeyName ) noexcept
+inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept
 {
-	aJSON[ aKeyName ] = aObject;
-	return aJSON;
+	return aJSON = aObject;
+}
+
+template<is_jsonable T, is_json_type JsonType>
+inline JsonType& AddToJSONKey( JsonType& aJSON, const T& aObject, const std::string_view aKeyName ) noexcept
+{
+	return AddToJSON( aJSON[ aKeyName ], aObject );
+}
+
+template<is_not_jsonable T, is_json_type JsonType>
+inline JsonType& AddToJSONKey( JsonType& aJSON, const T& aObject, const std::string_view aKeyName ) noexcept
+{
+	return AddToJSON( aJSON[ aKeyName ], aObject );
 }
 
 } //futsim namespace

--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -65,6 +65,15 @@ inline T ValueFromJSONString( const std::string_view& aJSONString, auto&&... aAr
 template<is_jsonable T, is_json_type JsonType>
 inline JsonType& AddToJSON( JsonType& aJSON, const T& aValue ) noexcept;
 
+/**
+ * @brief Helper function to add a value to a key in a JSON object.
+ * @param aJSON JSON object.
+ * @param aValue Value to add.
+ * @param aKeyName Name of the key to search.
+*/
+template<is_json_type JsonType>
+inline JsonType& AddToJSON( JsonType& aJSON, const auto& aValue, const std::string_view aKeyName ) noexcept;
+
 template<typename T, is_json_type JsonType>
 inline T ValueFromRequiredJSONKey( const JsonType& aJSON, const std::string_view aKeyName )
 {
@@ -93,7 +102,13 @@ inline T ValueFromJSONString( const std::string_view& aJSONString, auto&&... aAr
 template<is_jsonable T, is_json_type JsonType>
 inline JsonType& AddToJSON( JsonType& aJSON, const T& aValue ) noexcept
 {
-	aJSON[ T::JSON_KEY ] = aValue.ToJSON();
+	return AddToJSON( aJSON, aValue.ToJSON(), T::JSON_KEY );
+}
+
+template<is_json_type JsonType>
+inline JsonType& AddToJSON( JsonType& aJSON, const auto& aValue, const std::string_view aKeyName ) noexcept
+{
+	aJSON[ aKeyName ] = aValue;
 	return aJSON;
 }
 

--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -58,12 +58,12 @@ template<is_json_constructible T>
 inline T ValueFromJSONString( const std::string_view& aJSONString, auto&&... aArgs );
 
 /**
- * @brief Helper function to add a jsonable class to a JSON object.
+ * @brief Helper function to add a jsonable object to a JSON object.
  * @param aJSON JSON object.
- * @param aValue Value to add.
+ * @param aObject Value to add.
 */
 template<is_jsonable T, is_json_type JsonType>
-inline JsonType& AddToJSON( JsonType& aJSON, const T& aValue ) noexcept;
+inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept;
 
 /**
  * @brief Helper function to add a value to a key in a JSON object.
@@ -100,9 +100,9 @@ inline T ValueFromJSONString( const std::string_view& aJSONString, auto&&... aAr
 }
 
 template<is_jsonable T, is_json_type JsonType>
-inline JsonType& AddToJSON( JsonType& aJSON, const T& aValue ) noexcept
+inline JsonType& AddToJSON( JsonType& aJSON, const T& aObject ) noexcept
 {
-	return AddToJSON( aJSON, aValue.ToJSON(), T::JSON_KEY );
+	return AddToJSON( aJSON, aObject.ToJSON(), T::JSON_KEY );
 }
 
 template<is_json_type JsonType>

--- a/include/football/CPlayer.h
+++ b/include/football/CPlayer.h
@@ -48,7 +48,7 @@ protected:
 	/**
 	 * @copydoc IJsonable::ToJSON
 	*/
-	json JSON() const noexcept override;
+	void JSON( json& aJSON ) const noexcept override;
 
 public:
 	//! Retrieves the \copybrief mPlayerSkills

--- a/include/football/CPlayerSkills.h
+++ b/include/football/CPlayerSkills.h
@@ -4,8 +4,6 @@
 
 #include "football/CPlayerSkillsTypes.h"
 
-#include <string_view>
-
 namespace futsim
 {
 
@@ -53,7 +51,7 @@ private:
 	/**
 	 * @copydoc IJsonable::ToJSON
 	*/
-	json JSON() const noexcept override;
+	void JSON( json& aJSON ) const noexcept override;
 
 public:
 	//! Retrieves the \copybrief mGKSkill

--- a/include/football/CStadium.h
+++ b/include/football/CStadium.h
@@ -40,7 +40,7 @@ protected:
 	/**
 	 * @copydoc IJsonable::ToJSON
 	*/
-	json JSON() const noexcept override;
+	void JSON( json& aJSON ) const noexcept override;
 
 public:
 	//! Retrieves the \copybrief mName

--- a/src/CPerson.cpp
+++ b/src/CPerson.cpp
@@ -45,18 +45,14 @@ CPerson::CPerson( const json& aJSON ) try :
 }
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the player from JSON." )
 
-CPerson::json CPerson::JSON() const noexcept
+void CPerson::JSON( json& aJSON ) const noexcept
 {
-	json result;
-
-	AddToJSONKey( result, mFirstName, JSON_FIRST_NAME );
-	AddToJSONKey( result, mSurnames, JSON_SURNAMES );
+	AddToJSONKey( aJSON, mFirstName, JSON_FIRST_NAME );
+	AddToJSONKey( aJSON, mSurnames, JSON_SURNAMES );
 	if( mKnownName != mSurnames )
-		AddToJSONKey( result, mKnownName, JSON_KNOWN_NAME );
-	AddToJSONKey( result, mAge, JSON_AGE );
-	AddToJSONKey( result, ToString( mNationality ), JSON_NATIONALITY );
-
-	return result;
+		AddToJSONKey( aJSON, mKnownName, JSON_KNOWN_NAME );
+	AddToJSONKey( aJSON, mAge, JSON_AGE );
+	AddToJSONKey( aJSON, ToString( mNationality ), JSON_NATIONALITY );
 }
 
 const std::string_view CPerson::GetFirstName() const noexcept

--- a/src/CPerson.cpp
+++ b/src/CPerson.cpp
@@ -49,12 +49,12 @@ CPerson::json CPerson::JSON() const noexcept
 {
 	json result;
 
-	result[ JSON_FIRST_NAME ] = mFirstName;
-	result[ JSON_SURNAMES ] = mSurnames;
+	AddToJSONKey( result, mFirstName, JSON_FIRST_NAME );
+	AddToJSONKey( result, mSurnames, JSON_SURNAMES );
 	if( mKnownName != mSurnames )
-		result[ JSON_KNOWN_NAME ] = mKnownName;
-	result[ JSON_AGE ] = mAge;
-	result[ JSON_NATIONALITY ] = ToString( mNationality );
+		AddToJSONKey( result, mKnownName, JSON_KNOWN_NAME );
+	AddToJSONKey( result, mAge, JSON_AGE );
+	AddToJSONKey( result, ToString( mNationality ), JSON_NATIONALITY );
 
 	return result;
 }

--- a/src/IJsonable.cpp
+++ b/src/IJsonable.cpp
@@ -3,9 +3,9 @@
 namespace futsim
 {
 
-IJsonable::json IJsonable::ToJSON() const noexcept
+void IJsonable::ToJSON( json& aJSON ) const noexcept
 {
-	return this->JSON();
+	this->JSON( aJSON );
 }
 
 

--- a/src/football/CPlayer.cpp
+++ b/src/football/CPlayer.cpp
@@ -36,7 +36,8 @@ FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the p
 CPlayer::json CPlayer::JSON() const noexcept
 {
 	json result = CPerson::JSON();
-	result[ CPlayerSkills::JSON_KEY ] = mPlayerSkills.ToJSON();
+
+	AddToJSONKey( result, mPlayerSkills );
 
 	return result;
 }

--- a/src/football/CPlayer.cpp
+++ b/src/football/CPlayer.cpp
@@ -28,7 +28,7 @@ FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the p
 
 CPlayer::CPlayer( const json& aJSON ) try :
 	CPerson( aJSON ),
-	mPlayerSkills( ValueFromJSON<CPlayerSkills>( aJSON ) )
+	mPlayerSkills( ValueFromRequiredJSONKey<CPlayerSkills>( aJSON ) )
 {
 }
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the player from JSON." )

--- a/src/football/CPlayer.cpp
+++ b/src/football/CPlayer.cpp
@@ -33,13 +33,10 @@ CPlayer::CPlayer( const json& aJSON ) try :
 }
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the player from JSON." )
 
-CPlayer::json CPlayer::JSON() const noexcept
+void CPlayer::JSON( json& aJSON ) const noexcept
 {
-	json result = CPerson::JSON();
-
-	AddToJSONKey( result, mPlayerSkills );
-
-	return result;
+	CPerson::JSON( aJSON );
+	AddToJSONKey( aJSON, mPlayerSkills );
 }
 
 const CPlayerSkills CPlayer::GetPlayerSkills() const noexcept

--- a/src/football/CPlayerSkills.cpp
+++ b/src/football/CPlayerSkills.cpp
@@ -64,14 +64,14 @@ CPlayerSkills::json CPlayerSkills::JSON() const noexcept
 {
 	json result;
 
-	result[ JSON_GK_SKILL ] = mGKSkill;
-	result[ JSON_DF_SKILL ] = mDFSkill;
-	result[ JSON_MF_SKILL ] = mMFSkill;
-	result[ JSON_FW_SKILL ] = mFWSkill;
-	result[ JSON_GK_XP ] = mGKExperience;
-	result[ JSON_DF_XP ] = mDFExperience;
-	result[ JSON_MF_XP ] = mMFExperience;
-	result[ JSON_FW_XP ] = mFWExperience;
+	AddToJSONKey( result, mGKSkill, JSON_GK_SKILL );
+	AddToJSONKey( result, mDFSkill, JSON_DF_SKILL );
+	AddToJSONKey( result, mMFSkill, JSON_MF_SKILL );
+	AddToJSONKey( result, mFWSkill, JSON_FW_SKILL );
+	AddToJSONKey( result, mGKExperience, JSON_GK_XP );
+	AddToJSONKey( result, mDFExperience, JSON_DF_XP );
+	AddToJSONKey( result, mMFExperience, JSON_MF_XP );
+	AddToJSONKey( result, mFWExperience, JSON_FW_XP );
 
 	return result;
 }

--- a/src/football/CPlayerSkills.cpp
+++ b/src/football/CPlayerSkills.cpp
@@ -60,20 +60,16 @@ CPlayerSkills::CPlayerSkills( const json& aJSON ) try :
 }
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the player skills from JSON." )
 
-CPlayerSkills::json CPlayerSkills::JSON() const noexcept
+void CPlayerSkills::JSON( json& aJSON ) const noexcept
 {
-	json result;
-
-	AddToJSONKey( result, mGKSkill, JSON_GK_SKILL );
-	AddToJSONKey( result, mDFSkill, JSON_DF_SKILL );
-	AddToJSONKey( result, mMFSkill, JSON_MF_SKILL );
-	AddToJSONKey( result, mFWSkill, JSON_FW_SKILL );
-	AddToJSONKey( result, mGKExperience, JSON_GK_XP );
-	AddToJSONKey( result, mDFExperience, JSON_DF_XP );
-	AddToJSONKey( result, mMFExperience, JSON_MF_XP );
-	AddToJSONKey( result, mFWExperience, JSON_FW_XP );
-
-	return result;
+	AddToJSONKey( aJSON, mGKSkill, JSON_GK_SKILL );
+	AddToJSONKey( aJSON, mDFSkill, JSON_DF_SKILL );
+	AddToJSONKey( aJSON, mMFSkill, JSON_MF_SKILL );
+	AddToJSONKey( aJSON, mFWSkill, JSON_FW_SKILL );
+	AddToJSONKey( aJSON, mGKExperience, JSON_GK_XP );
+	AddToJSONKey( aJSON, mDFExperience, JSON_DF_XP );
+	AddToJSONKey( aJSON, mMFExperience, JSON_MF_XP );
+	AddToJSONKey( aJSON, mFWExperience, JSON_FW_XP );
 }
 
 const skill_type& CPlayerSkills::GetGKSkill() const noexcept

--- a/src/football/CStadium.cpp
+++ b/src/football/CStadium.cpp
@@ -50,9 +50,9 @@ CStadium::json CStadium::JSON() const noexcept
 {
 	json result;
 
-	result[ JSON_NAME ] = mName;
-	result[ JSON_CAPACITY ] = mCapacity;
-	result[ JSON_AMBIENT_FACTOR ] = mAmbientFactor;
+	AddToJSONKey( result, mName, JSON_NAME );
+	AddToJSONKey( result, mCapacity, JSON_CAPACITY );
+	AddToJSONKey( result, mAmbientFactor, JSON_AMBIENT_FACTOR );
 
 	return result;
 }

--- a/src/football/CStadium.cpp
+++ b/src/football/CStadium.cpp
@@ -46,15 +46,11 @@ CStadium::CStadium( const json& aJSON ) try :
 }
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the stadium from JSON." )
 
-CStadium::json CStadium::JSON() const noexcept
+void CStadium::JSON( json& aJSON ) const noexcept
 {
-	json result;
-
-	AddToJSONKey( result, mName, JSON_NAME );
-	AddToJSONKey( result, mCapacity, JSON_CAPACITY );
-	AddToJSONKey( result, mAmbientFactor, JSON_AMBIENT_FACTOR );
-
-	return result;
+	AddToJSONKey( aJSON, mName, JSON_NAME );
+	AddToJSONKey( aJSON, mCapacity, JSON_CAPACITY );
+	AddToJSONKey( aJSON, mAmbientFactor, JSON_AMBIENT_FACTOR );
 }
 
 const std::string_view CStadium::GetName() const noexcept

--- a/tests/unit/TPerson.cpp
+++ b/tests/unit/TPerson.cpp
@@ -22,32 +22,32 @@ void TPerson::TestExceptions() const
 		"The surnames cannot be empty." );
 
 	//! Test JSON constructor
-	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
+	CheckException( []() { ValueFromJSONKeyString<CPerson>( R"( {
 			"Person": {}
 		} )" ); }, "key 'First name' not found" );
-	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
+	CheckException( []() { ValueFromJSONKeyString<CPerson>( R"( {
 			"Person": {
 				"First name": ""
 			}
 		} )" ); }, "The name cannot be empty." );
-	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
+	CheckException( []() { ValueFromJSONKeyString<CPerson>( R"( {
 			"Person": {
 				"First name": "Lionel"
 			}
 		} )" ); }, "key 'Surnames' not found" );
-	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
+	CheckException( []() { ValueFromJSONKeyString<CPerson>( R"( {
 			"Person": {
 				"First name": "Lionel",
 				"Surnames": ""
 			}
 		} )" ); }, "The surnames cannot be empty." );
-	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
+	CheckException( []() { ValueFromJSONKeyString<CPerson>( R"( {
 			"Person": {
 				"First name": "Lionel",
 				"Surnames": "Messi"
 			}
 		} )" ); }, "key 'Age' not found" );
-	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
+	CheckException( []() { ValueFromJSONKeyString<CPerson>( R"( {
 			"Person": {
 				"First name": "Lionel",
 				"Surnames": "Messi",
@@ -63,7 +63,7 @@ std::vector<std::string> TPerson::ObtainedResults() const noexcept
 	for( const auto& person : {
 		CPerson{ "Lorenzo", "Blanco", {}, 35, futsim::E_NATIONALITY::ARG },
 		CPerson{ "Pedro", "Pérez Martínez", "Perico", 20, futsim::E_NATIONALITY::ESP },
-		ValueFromJSONString<CPerson>( R"( {
+		ValueFromJSONKeyString<CPerson>( R"( {
 			"Person": {
 				"Surnames": "Blanco",
 				"First name": "Lorenzo",
@@ -71,7 +71,7 @@ std::vector<std::string> TPerson::ObtainedResults() const noexcept
 				"Nationality": "ARG"
 			}
 		} )" ),
-		ValueFromJSONString<CPerson>( R"( {
+		ValueFromJSONKeyString<CPerson>( R"( {
 			"Person": {
 				"First name": "Pedro",
 				"Surnames": "Pérez Martínez",

--- a/tests/unit/TPerson.cpp
+++ b/tests/unit/TPerson.cpp
@@ -87,7 +87,7 @@ std::vector<std::string> TPerson::ObtainedResults() const noexcept
 		result.push_back( std::string{ CPerson::JSON_AGE } + ": " + std::to_string( person.GetAge() ) );
 		result.push_back( std::string{ CPerson::JSON_NATIONALITY } + ": " + futsim::ToString( person.GetNationality() ) );
 		futsim::IJsonableTypes::json outputJSON;
-		outputJSON[ CPerson::JSON_KEY ] = person.ToJSON();
+		AddToJSONKey( outputJSON, person );
 		result.push_back( outputJSON.dump( 1, '\t' ) );
 	}
 

--- a/tests/unit/TPerson.cpp
+++ b/tests/unit/TPerson.cpp
@@ -4,6 +4,8 @@
 
 #include "NationalityUtils.h"
 
+#include "JsonUtils.h"
+
 #include <iostream>
 
 using namespace futsim;
@@ -20,38 +22,38 @@ void TPerson::TestExceptions() const
 		"The surnames cannot be empty." );
 
 	//! Test JSON constructor
-	CheckException( []() { CPerson{ json::parse( R"( {
+	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
 			"Person": {}
-		} )" )[ CPerson::JSON_KEY ] }; }, "key 'First name' not found" );
-	CheckException( []() { CPerson{ json::parse( R"( {
+		} )" ) ); }, "key 'First name' not found" );
+	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
 			"Person": {
 				"First name": ""
 			}
-		} )" )[ CPerson::JSON_KEY ] }; }, "The name cannot be empty." );
-	CheckException( []() { CPerson{ json::parse( R"( {
+		} )" ) ); }, "The name cannot be empty." );
+	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
 			"Person": {
 				"First name": "Lionel"
 			}
-		} )" )[ CPerson::JSON_KEY ] }; }, "key 'Surnames' not found" );
-	CheckException( []() { CPerson{ json::parse( R"( {
+		} )" ) ); }, "key 'Surnames' not found" );
+	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
 			"Person": {
 				"First name": "Lionel",
 				"Surnames": ""
 			}
-		} )" )[ CPerson::JSON_KEY ] }; }, "The surnames cannot be empty." );
-	CheckException( []() { CPerson{ json::parse( R"( {
+		} )" ) ); }, "The surnames cannot be empty." );
+	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
 			"Person": {
 				"First name": "Lionel",
 				"Surnames": "Messi"
 			}
-		} )" )[ CPerson::JSON_KEY ] }; }, "key 'Age' not found" );
-	CheckException( []() { CPerson{ json::parse( R"( {
+		} )" ) ); }, "key 'Age' not found" );
+	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
 			"Person": {
 				"First name": "Lionel",
 				"Surnames": "Messi",
 				"Age": 35
 			}
-		} )" )[ CPerson::JSON_KEY ] }; }, "key 'Nationality' not found" );
+		} )" ) ); }, "key 'Nationality' not found" );
 }
 
 std::vector<std::string> TPerson::ObtainedResults() const noexcept
@@ -61,15 +63,15 @@ std::vector<std::string> TPerson::ObtainedResults() const noexcept
 	for( const auto& person : {
 		CPerson{ "Lorenzo", "Blanco", {}, 35, futsim::E_NATIONALITY::ARG },
 		CPerson{ "Pedro", "Pérez Martínez", "Perico", 20, futsim::E_NATIONALITY::ESP },
-		CPerson{ json::parse( R"( {
+		ValueFromJSON<CPerson>( json::parse( R"( {
 			"Person": {
 				"Surnames": "Blanco",
 				"First name": "Lorenzo",
 				"Age": 35,
 				"Nationality": "ARG"
 			}
-		} )" )[ CPerson::JSON_KEY ] },
-		CPerson{ json::parse( R"( {
+		} )" ) ),
+		ValueFromJSON<CPerson>( json::parse( R"( {
 			"Person": {
 				"First name": "Pedro",
 				"Surnames": "Pérez Martínez",
@@ -77,7 +79,7 @@ std::vector<std::string> TPerson::ObtainedResults() const noexcept
 				"Age": 20,
 				"Nationality": "ESP"
 			}
-		} )" )[ CPerson::JSON_KEY ] } } )
+		} )" ) ) } )
 	{
 		result.push_back( std::string{ CPerson::JSON_FIRST_NAME } + ": " + std::string{ person.GetFirstName() } );
 		result.push_back( std::string{ CPerson::JSON_SURNAMES } + ": " + std::string{ person.GetSurnames() } );

--- a/tests/unit/TPerson.cpp
+++ b/tests/unit/TPerson.cpp
@@ -22,38 +22,38 @@ void TPerson::TestExceptions() const
 		"The surnames cannot be empty." );
 
 	//! Test JSON constructor
-	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
+	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
 			"Person": {}
-		} )" ) ); }, "key 'First name' not found" );
-	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
+		} )" ); }, "key 'First name' not found" );
+	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
 			"Person": {
 				"First name": ""
 			}
-		} )" ) ); }, "The name cannot be empty." );
-	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
+		} )" ); }, "The name cannot be empty." );
+	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
 			"Person": {
 				"First name": "Lionel"
 			}
-		} )" ) ); }, "key 'Surnames' not found" );
-	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
+		} )" ); }, "key 'Surnames' not found" );
+	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
 			"Person": {
 				"First name": "Lionel",
 				"Surnames": ""
 			}
-		} )" ) ); }, "The surnames cannot be empty." );
-	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
+		} )" ); }, "The surnames cannot be empty." );
+	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
 			"Person": {
 				"First name": "Lionel",
 				"Surnames": "Messi"
 			}
-		} )" ) ); }, "key 'Age' not found" );
-	CheckException( []() { ValueFromJSON<CPerson>( json::parse( R"( {
+		} )" ); }, "key 'Age' not found" );
+	CheckException( []() { ValueFromJSONString<CPerson>( R"( {
 			"Person": {
 				"First name": "Lionel",
 				"Surnames": "Messi",
 				"Age": 35
 			}
-		} )" ) ); }, "key 'Nationality' not found" );
+		} )" ); }, "key 'Nationality' not found" );
 }
 
 std::vector<std::string> TPerson::ObtainedResults() const noexcept
@@ -63,15 +63,15 @@ std::vector<std::string> TPerson::ObtainedResults() const noexcept
 	for( const auto& person : {
 		CPerson{ "Lorenzo", "Blanco", {}, 35, futsim::E_NATIONALITY::ARG },
 		CPerson{ "Pedro", "Pérez Martínez", "Perico", 20, futsim::E_NATIONALITY::ESP },
-		ValueFromJSON<CPerson>( json::parse( R"( {
+		ValueFromJSONString<CPerson>( R"( {
 			"Person": {
 				"Surnames": "Blanco",
 				"First name": "Lorenzo",
 				"Age": 35,
 				"Nationality": "ARG"
 			}
-		} )" ) ),
-		ValueFromJSON<CPerson>( json::parse( R"( {
+		} )" ),
+		ValueFromJSONString<CPerson>( R"( {
 			"Person": {
 				"First name": "Pedro",
 				"Surnames": "Pérez Martínez",
@@ -79,7 +79,7 @@ std::vector<std::string> TPerson::ObtainedResults() const noexcept
 				"Age": 20,
 				"Nationality": "ESP"
 			}
-		} )" ) ) } )
+		} )" ) } )
 	{
 		result.push_back( std::string{ CPerson::JSON_FIRST_NAME } + ": " + std::string{ person.GetFirstName() } );
 		result.push_back( std::string{ CPerson::JSON_SURNAMES } + ": " + std::string{ person.GetSurnames() } );

--- a/tests/unit/football/TPlayer.cpp
+++ b/tests/unit/football/TPlayer.cpp
@@ -70,9 +70,9 @@ std::vector<std::string> TPlayer::ObtainedResults() const noexcept
 			}
 		} )" ) } )
 	{
-		result.push_back( std::string{ CPlayerSkills::JSON_KEY } + ": " + player.GetPlayerSkills().ToJSON().dump( 1, '\t' ) );
+		result.push_back( player.GetPlayerSkills().JSON_KEY.data() );
 		futsim::IJsonableTypes::json outputJSON;
-		outputJSON[ CPlayer::JSON_KEY ] = player.ToJSON();
+		AddToJSONKey( outputJSON, player );
 		result.push_back( outputJSON.dump( 1, '\t' ) );
 	}
 
@@ -82,16 +82,7 @@ std::vector<std::string> TPlayer::ObtainedResults() const noexcept
 std::vector<std::string> TPlayer::ExpectedResults() const noexcept
 {
 	std::vector<std::string> result{
-		"Player skills: {\n"
-		"	\"GK skill\": 1,\n"
-		"	\"DF skill\": 1,\n"
-		"	\"MF skill\": 1,\n"
-		"	\"FW skill\": 99,\n"
-		"	\"GK experience\": 0,\n"
-		"	\"DF experience\": 0,\n"
-		"	\"MF experience\": 0,\n"
-		"	\"FW experience\": 0\n"
-		"}",
+		"Player skills",
 		"{\n"
 		"	\"Player\": {\n"
 		"		\"First name\": \"Lionel\",\n"
@@ -110,16 +101,7 @@ std::vector<std::string> TPlayer::ExpectedResults() const noexcept
 		"		}\n"
 		"	}\n"
 		"}",
-		"Player skills: {\n"
-		"	\"GK skill\": 1,\n"
-		"	\"DF skill\": 1,\n"
-		"	\"MF skill\": 1,\n"
-		"	\"FW skill\": 80,\n"
-		"	\"GK experience\": 0,\n"
-		"	\"DF experience\": 0,\n"
-		"	\"MF experience\": 0,\n"
-		"	\"FW experience\": 0\n"
-		"}",
+		"Player skills",
 		"{\n"
 		"	\"Player\": {\n"
 		"		\"First name\": \"Ansu\",\n"

--- a/tests/unit/football/TPlayer.cpp
+++ b/tests/unit/football/TPlayer.cpp
@@ -15,14 +15,14 @@ INITIALIZE_TEST( TPlayer )
 void TPlayer::TestExceptions() const
 {
 	//! Test JSON constructor
-	CheckException( []() { futsim::ValueFromJSON<CPlayer>( json::parse( R"( {
+	CheckException( []() { futsim::ValueFromJSONString<CPlayer>( R"( {
 			"Player": {
 				"First name": "Lionel",
 				"Surnames": "Messi",
 				"Age": 35,
 				"Nationality": "ARG"
 			}
-		} )" ) ); }, "key 'Player skills' not found" );
+		} )" ); }, "key 'Player skills' not found" );
 }
 
 std::vector<std::string> TPlayer::ObtainedResults() const noexcept
@@ -32,7 +32,7 @@ std::vector<std::string> TPlayer::ObtainedResults() const noexcept
 	for( const auto& player : {
 		CPlayer{ "Lionel", "Messi", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ 1, 1, 1, 99, 0, 0, 0, 0 } },
 		CPlayer{ "Ansu", "Fati", "Ansu Fati", 20, futsim::E_NATIONALITY::ESP, CPlayerSkills{ 1, 1, 1, 80, 0, 0, 0, 0 } },
-		futsim::ValueFromJSON<CPlayer>( json::parse( R"( {
+		futsim::ValueFromJSONString<CPlayer>( R"( {
 			"Player": {
 				"Surnames": "Messi",
 				"First name": "Lionel",
@@ -49,8 +49,8 @@ std::vector<std::string> TPlayer::ObtainedResults() const noexcept
 					"FW experience": 0
 				}
 			}
-		} )" ) ),
-		futsim::ValueFromJSON<CPlayer>( json::parse( R"( {
+		} )" ),
+		futsim::ValueFromJSONString<CPlayer>( R"( {
 			"Player": {
 				"First name": "Ansu",
 				"Surnames": "Fati",
@@ -68,7 +68,7 @@ std::vector<std::string> TPlayer::ObtainedResults() const noexcept
 					"FW experience": 0
 				}
 			}
-		} )" ) ) } )
+		} )" ) } )
 	{
 		result.push_back( std::string{ CPlayerSkills::JSON_KEY } + ": " + player.GetPlayerSkills().ToJSON().dump( 1, '\t' ) );
 		futsim::IJsonableTypes::json outputJSON;

--- a/tests/unit/football/TPlayer.cpp
+++ b/tests/unit/football/TPlayer.cpp
@@ -15,7 +15,7 @@ INITIALIZE_TEST( TPlayer )
 void TPlayer::TestExceptions() const
 {
 	//! Test JSON constructor
-	CheckException( []() { futsim::ValueFromJSONString<CPlayer>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayer>( R"( {
 			"Player": {
 				"First name": "Lionel",
 				"Surnames": "Messi",
@@ -32,7 +32,7 @@ std::vector<std::string> TPlayer::ObtainedResults() const noexcept
 	for( const auto& player : {
 		CPlayer{ "Lionel", "Messi", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ 1, 1, 1, 99, 0, 0, 0, 0 } },
 		CPlayer{ "Ansu", "Fati", "Ansu Fati", 20, futsim::E_NATIONALITY::ESP, CPlayerSkills{ 1, 1, 1, 80, 0, 0, 0, 0 } },
-		futsim::ValueFromJSONString<CPlayer>( R"( {
+		futsim::ValueFromJSONKeyString<CPlayer>( R"( {
 			"Player": {
 				"Surnames": "Messi",
 				"First name": "Lionel",
@@ -50,7 +50,7 @@ std::vector<std::string> TPlayer::ObtainedResults() const noexcept
 				}
 			}
 		} )" ),
-		futsim::ValueFromJSONString<CPlayer>( R"( {
+		futsim::ValueFromJSONKeyString<CPlayer>( R"( {
 			"Player": {
 				"First name": "Ansu",
 				"Surnames": "Fati",

--- a/tests/unit/football/TPlayer.cpp
+++ b/tests/unit/football/TPlayer.cpp
@@ -2,6 +2,7 @@
 
 #include "football/CPlayer.h"
 
+#include "JsonUtils.h"
 #include "NationalityUtils.h"
 
 #include <iostream>
@@ -14,14 +15,14 @@ INITIALIZE_TEST( TPlayer )
 void TPlayer::TestExceptions() const
 {
 	//! Test JSON constructor
-	CheckException( []() { CPlayer{ json::parse( R"( {
+	CheckException( []() { futsim::ValueFromJSON<CPlayer>( json::parse( R"( {
 			"Player": {
 				"First name": "Lionel",
 				"Surnames": "Messi",
 				"Age": 35,
 				"Nationality": "ARG"
 			}
-		} )" )[ CPlayer::JSON_KEY ] }; }, "key 'Player skills' not found" );
+		} )" ) ); }, "key 'Player skills' not found" );
 }
 
 std::vector<std::string> TPlayer::ObtainedResults() const noexcept
@@ -31,7 +32,7 @@ std::vector<std::string> TPlayer::ObtainedResults() const noexcept
 	for( const auto& player : {
 		CPlayer{ "Lionel", "Messi", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ 1, 1, 1, 99, 0, 0, 0, 0 } },
 		CPlayer{ "Ansu", "Fati", "Ansu Fati", 20, futsim::E_NATIONALITY::ESP, CPlayerSkills{ 1, 1, 1, 80, 0, 0, 0, 0 } },
-		CPlayer{ json::parse( R"( {
+		futsim::ValueFromJSON<CPlayer>( json::parse( R"( {
 			"Player": {
 				"Surnames": "Messi",
 				"First name": "Lionel",
@@ -48,8 +49,8 @@ std::vector<std::string> TPlayer::ObtainedResults() const noexcept
 					"FW experience": 0
 				}
 			}
-		} )" )[ CPlayer::JSON_KEY ] },
-		CPlayer{ json::parse( R"( {
+		} )" ) ),
+		futsim::ValueFromJSON<CPlayer>( json::parse( R"( {
 			"Player": {
 				"First name": "Ansu",
 				"Surnames": "Fati",
@@ -67,7 +68,7 @@ std::vector<std::string> TPlayer::ObtainedResults() const noexcept
 					"FW experience": 0
 				}
 			}
-		} )" )[ CPlayer::JSON_KEY ] } } )
+		} )" ) ) } )
 	{
 		result.push_back( std::string{ CPlayerSkills::JSON_KEY } + ": " + player.GetPlayerSkills().ToJSON().dump( 1, '\t' ) );
 		futsim::IJsonableTypes::json outputJSON;

--- a/tests/unit/football/TPlayerSkills.cpp
+++ b/tests/unit/football/TPlayerSkills.cpp
@@ -2,6 +2,8 @@
 
 #include "football/CPlayerSkills.h"
 
+#include "JsonUtils.h"
+
 #include <iostream>
 
 using namespace futsim::football;
@@ -18,62 +20,62 @@ void TPlayerSkills::TestExceptions() const
 	CheckException( []() { CPlayerSkills{ 1, 1, 1, 0, 1, 1, 1, 1 }; }, "The FW skill value must be greater than 0." );
 
 	//! Test JSON constructor
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "key 'GK skill' not found" );
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+		} )" ) ); }, "key 'GK skill' not found" );
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 0
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "The GK skill value must be greater than 0." );
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+		} )" ) ); }, "The GK skill value must be greater than 0." );
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 1
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "key 'DF skill' not found" );
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+		} )" ) ); }, "key 'DF skill' not found" );
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 0
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "The DF skill value must be greater than 0." );
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+		} )" ) ); }, "The DF skill value must be greater than 0." );
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "key 'MF skill' not found" );
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+		} )" ) ); }, "key 'MF skill' not found" );
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
 				"MF skill": 0
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "The MF skill value must be greater than 0." );
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+		} )" ) ); }, "The MF skill value must be greater than 0." );
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
 				"MF skill": 1
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "key 'FW skill' not found" );
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+		} )" ) ); }, "key 'FW skill' not found" );
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
 				"MF skill": 1,
 				"FW skill": 0
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "The FW skill value must be greater than 0." );
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+		} )" ) ); }, "The FW skill value must be greater than 0." );
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
 				"MF skill": 1,
 				"FW skill": 1
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "key 'GK experience' not found" );
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+		} )" ) ); }, "key 'GK experience' not found" );
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
@@ -81,8 +83,8 @@ void TPlayerSkills::TestExceptions() const
 				"FW skill": 1,
 				"GK experience": 0
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "key 'DF experience' not found" );
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+		} )" ) ); }, "key 'DF experience' not found" );
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
@@ -91,8 +93,8 @@ void TPlayerSkills::TestExceptions() const
 				"GK experience": 0,
 				"DF experience": 0
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "key 'MF experience' not found" );
-	CheckException( []() { CPlayerSkills{ json::parse( R"( {
+		} )" ) ); }, "key 'MF experience' not found" );
+	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
@@ -102,7 +104,7 @@ void TPlayerSkills::TestExceptions() const
 				"DF experience": 0,
 				"MF experience": 0
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] }; }, "key 'FW experience' not found" );
+		} )" ) ); }, "key 'FW experience' not found" );
 }
 
 std::vector<std::string> TPlayerSkills::ObtainedResults() const noexcept
@@ -112,7 +114,7 @@ std::vector<std::string> TPlayerSkills::ObtainedResults() const noexcept
 	for( const auto& playerSkills : {
 		CPlayerSkills{ 1, 1, 1, 1, 0, 0, 0, 0 },
 		CPlayerSkills{ 99, 10, 50, 10, 60, 20, 45, 0 },
-		CPlayerSkills{ json::parse( R"( {
+		futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"MF skill": 1,
@@ -123,8 +125,8 @@ std::vector<std::string> TPlayerSkills::ObtainedResults() const noexcept
 				"MF experience": 0,
 				"FW experience": 0
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] },
-		CPlayerSkills{ json::parse( R"( {
+		} )" ) ),
+		futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
 			"Player skills": {
 				"GK experience": 60,
 				"GK skill": 99,
@@ -135,7 +137,7 @@ std::vector<std::string> TPlayerSkills::ObtainedResults() const noexcept
 				"DF experience": 20,
 				"FW experience": 0
 			}
-		} )" )[ CPlayerSkills::JSON_KEY ] } } )
+		} )" ) ) } )
 	{
 		result.push_back( std::string{ CPlayerSkills::JSON_GK_SKILL } + ": " + std::to_string( playerSkills.GetGKSkill() ) );
 		result.push_back( std::string{ CPlayerSkills::JSON_DF_SKILL } + ": " + std::to_string( playerSkills.GetDFSkill() ) );

--- a/tests/unit/football/TPlayerSkills.cpp
+++ b/tests/unit/football/TPlayerSkills.cpp
@@ -20,46 +20,46 @@ void TPlayerSkills::TestExceptions() const
 	CheckException( []() { CPlayerSkills{ 1, 1, 1, 0, 1, 1, 1, 1 }; }, "The FW skill value must be greater than 0." );
 
 	//! Test JSON constructor
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {}
 		} )" ); }, "key 'GK skill' not found" );
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 0
 			}
 		} )" ); }, "The GK skill value must be greater than 0." );
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1
 			}
 		} )" ); }, "key 'DF skill' not found" );
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 0
 			}
 		} )" ); }, "The DF skill value must be greater than 0." );
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1
 			}
 		} )" ); }, "key 'MF skill' not found" );
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
 				"MF skill": 0
 			}
 		} )" ); }, "The MF skill value must be greater than 0." );
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
 				"MF skill": 1
 			}
 		} )" ); }, "key 'FW skill' not found" );
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
@@ -67,7 +67,7 @@ void TPlayerSkills::TestExceptions() const
 				"FW skill": 0
 			}
 		} )" ); }, "The FW skill value must be greater than 0." );
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
@@ -75,7 +75,7 @@ void TPlayerSkills::TestExceptions() const
 				"FW skill": 1
 			}
 		} )" ); }, "key 'GK experience' not found" );
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
@@ -84,7 +84,7 @@ void TPlayerSkills::TestExceptions() const
 				"GK experience": 0
 			}
 		} )" ); }, "key 'DF experience' not found" );
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
@@ -94,7 +94,7 @@ void TPlayerSkills::TestExceptions() const
 				"DF experience": 0
 			}
 		} )" ); }, "key 'MF experience' not found" );
-	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
@@ -114,7 +114,7 @@ std::vector<std::string> TPlayerSkills::ObtainedResults() const noexcept
 	for( const auto& playerSkills : {
 		CPlayerSkills{ 1, 1, 1, 1, 0, 0, 0, 0 },
 		CPlayerSkills{ 99, 10, 50, 10, 60, 20, 45, 0 },
-		futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+		futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"MF skill": 1,
@@ -126,7 +126,7 @@ std::vector<std::string> TPlayerSkills::ObtainedResults() const noexcept
 				"FW experience": 0
 			}
 		} )" ),
-		futsim::ValueFromJSONString<CPlayerSkills>( R"( {
+		futsim::ValueFromJSONKeyString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK experience": 60,
 				"GK skill": 99,

--- a/tests/unit/football/TPlayerSkills.cpp
+++ b/tests/unit/football/TPlayerSkills.cpp
@@ -148,7 +148,7 @@ std::vector<std::string> TPlayerSkills::ObtainedResults() const noexcept
 		result.push_back( std::string{ CPlayerSkills::JSON_MF_XP } + ": " + std::to_string( playerSkills.GetMFExperience() ) );
 		result.push_back( std::string{ CPlayerSkills::JSON_FW_XP } + ": " + std::to_string( playerSkills.GetFWExperience() ) );
 		futsim::IJsonableTypes::json outputJSON;
-		outputJSON[ CPlayerSkills::JSON_KEY ] = playerSkills.ToJSON();
+		AddToJSONKey( outputJSON, playerSkills );
 		result.push_back( outputJSON.dump( 1, '\t' ) );
 	}
 

--- a/tests/unit/football/TPlayerSkills.cpp
+++ b/tests/unit/football/TPlayerSkills.cpp
@@ -20,62 +20,62 @@ void TPlayerSkills::TestExceptions() const
 	CheckException( []() { CPlayerSkills{ 1, 1, 1, 0, 1, 1, 1, 1 }; }, "The FW skill value must be greater than 0." );
 
 	//! Test JSON constructor
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {}
-		} )" ) ); }, "key 'GK skill' not found" );
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ); }, "key 'GK skill' not found" );
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 0
 			}
-		} )" ) ); }, "The GK skill value must be greater than 0." );
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ); }, "The GK skill value must be greater than 0." );
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1
 			}
-		} )" ) ); }, "key 'DF skill' not found" );
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ); }, "key 'DF skill' not found" );
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 0
 			}
-		} )" ) ); }, "The DF skill value must be greater than 0." );
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ); }, "The DF skill value must be greater than 0." );
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1
 			}
-		} )" ) ); }, "key 'MF skill' not found" );
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ); }, "key 'MF skill' not found" );
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
 				"MF skill": 0
 			}
-		} )" ) ); }, "The MF skill value must be greater than 0." );
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ); }, "The MF skill value must be greater than 0." );
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
 				"MF skill": 1
 			}
-		} )" ) ); }, "key 'FW skill' not found" );
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ); }, "key 'FW skill' not found" );
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
 				"MF skill": 1,
 				"FW skill": 0
 			}
-		} )" ) ); }, "The FW skill value must be greater than 0." );
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ); }, "The FW skill value must be greater than 0." );
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
 				"MF skill": 1,
 				"FW skill": 1
 			}
-		} )" ) ); }, "key 'GK experience' not found" );
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ); }, "key 'GK experience' not found" );
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
@@ -83,8 +83,8 @@ void TPlayerSkills::TestExceptions() const
 				"FW skill": 1,
 				"GK experience": 0
 			}
-		} )" ) ); }, "key 'DF experience' not found" );
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ); }, "key 'DF experience' not found" );
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
@@ -93,8 +93,8 @@ void TPlayerSkills::TestExceptions() const
 				"GK experience": 0,
 				"DF experience": 0
 			}
-		} )" ) ); }, "key 'MF experience' not found" );
-	CheckException( []() { futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ); }, "key 'MF experience' not found" );
+	CheckException( []() { futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"DF skill": 1,
@@ -104,7 +104,7 @@ void TPlayerSkills::TestExceptions() const
 				"DF experience": 0,
 				"MF experience": 0
 			}
-		} )" ) ); }, "key 'FW experience' not found" );
+		} )" ); }, "key 'FW experience' not found" );
 }
 
 std::vector<std::string> TPlayerSkills::ObtainedResults() const noexcept
@@ -114,7 +114,7 @@ std::vector<std::string> TPlayerSkills::ObtainedResults() const noexcept
 	for( const auto& playerSkills : {
 		CPlayerSkills{ 1, 1, 1, 1, 0, 0, 0, 0 },
 		CPlayerSkills{ 99, 10, 50, 10, 60, 20, 45, 0 },
-		futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK skill": 1,
 				"MF skill": 1,
@@ -125,8 +125,8 @@ std::vector<std::string> TPlayerSkills::ObtainedResults() const noexcept
 				"MF experience": 0,
 				"FW experience": 0
 			}
-		} )" ) ),
-		futsim::ValueFromJSON<CPlayerSkills>( json::parse( R"( {
+		} )" ),
+		futsim::ValueFromJSONString<CPlayerSkills>( R"( {
 			"Player skills": {
 				"GK experience": 60,
 				"GK skill": 99,
@@ -137,7 +137,7 @@ std::vector<std::string> TPlayerSkills::ObtainedResults() const noexcept
 				"DF experience": 20,
 				"FW experience": 0
 			}
-		} )" ) ) } )
+		} )" ) } )
 	{
 		result.push_back( std::string{ CPlayerSkills::JSON_GK_SKILL } + ": " + std::to_string( playerSkills.GetGKSkill() ) );
 		result.push_back( std::string{ CPlayerSkills::JSON_DF_SKILL } + ": " + std::to_string( playerSkills.GetDFSkill() ) );

--- a/tests/unit/football/TStadium.cpp
+++ b/tests/unit/football/TStadium.cpp
@@ -73,7 +73,7 @@ std::vector<std::string> TStadium::ObtainedResults() const noexcept
 		result.push_back( std::string{ CStadium::JSON_CAPACITY } + ": " + std::to_string( stadium.GetCapacity() ) );
 		result.push_back( std::string{ CStadium::JSON_AMBIENT_FACTOR } + ": " + std::to_string( stadium.GetAmbientFactor() ) );
 		futsim::IJsonableTypes::json outputJSON;
-		outputJSON[ CStadium::JSON_KEY ] = stadium.ToJSON();
+		AddToJSONKey( outputJSON, stadium );
 		result.push_back( outputJSON.dump( 1, '\t' ) );
 	}
 

--- a/tests/unit/football/TStadium.cpp
+++ b/tests/unit/football/TStadium.cpp
@@ -18,33 +18,33 @@ void TStadium::TestExceptions() const
 	CheckException( []() { CStadium{ "Camp Nou", 98000, -2 }; }, "The ambient factor cannot be negative." );
 
 	//! Test JSON constructor
-	CheckException( []() { futsim::ValueFromJSON<CStadium>( json::parse( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CStadium>( R"( {
 			"Stadium": {}
-		} )" ) ); }, "key 'Name' not found" );
-	CheckException( []() { futsim::ValueFromJSON<CStadium>( json::parse( R"( {
+		} )" ); }, "key 'Name' not found" );
+	CheckException( []() { futsim::ValueFromJSONKeyString<CStadium>( R"( {
 			"Stadium": {
 				"Name": ""
 			}
-		} )" ) ); }, "The stadium name cannot be empty." );
-	CheckException( []() { futsim::ValueFromJSON<CStadium>( json::parse( R"( {
+		} )" ); }, "The stadium name cannot be empty." );
+	CheckException( []() { futsim::ValueFromJSONKeyString<CStadium>( R"( {
 			"Stadium": {
 				"Name": "Camp Nou"
 			}
-		} )" ) ); }, "key 'Capacity' not found" );
-	CheckException( []() { futsim::ValueFromJSON<CStadium>( json::parse( R"( {
+		} )" ); }, "key 'Capacity' not found" );
+	CheckException( []() { futsim::ValueFromJSONKeyString<CStadium>( R"( {
 			"Stadium": {
 				"Name": "Camp Nou",
 				"Capacity": 98000
 			}
-		} )" ) ); }, "key 'Ambient factor' not found" );
+		} )" ); }, "key 'Ambient factor' not found" );
 
-	CheckException( []() { futsim::ValueFromJSON<CStadium>( json::parse( R"( {
+	CheckException( []() { futsim::ValueFromJSONKeyString<CStadium>( R"( {
 			"Stadium": {
 				"Name": "Camp Nou",
 				"Capacity": 98000,
 				"Ambient factor": -2
 			}
-		} )" ) ); }, "The ambient factor cannot be negative." );
+		} )" ); }, "The ambient factor cannot be negative." );
 }
 
 std::vector<std::string> TStadium::ObtainedResults() const noexcept
@@ -54,20 +54,20 @@ std::vector<std::string> TStadium::ObtainedResults() const noexcept
 	for( const auto& stadium : {
 		CStadium{ "Camp Nou", 98000, 0.8 },
 		CStadium{ "The New Lawn", 5147, 0.5 },
-		futsim::ValueFromJSON<CStadium>( json::parse( R"( {
+		futsim::ValueFromJSONKeyString<CStadium>( R"( {
 			"Stadium": {
 				"Name": "Camp Nou",
 				"Capacity": 98000,
 				"Ambient factor": 0.8
 			}
-		} )" ) ),
-		futsim::ValueFromJSON<CStadium>( json::parse( R"( {
+		} )" ),
+		futsim::ValueFromJSONKeyString<CStadium>( R"( {
 			"Stadium": {
 				"Name": "The New Lawn",
 				"Capacity": 5147,
 				"Ambient factor": 0.5
 			}
-		} )" ) ) } )
+		} )" ) } )
 	{
 		result.push_back( std::string{ CStadium::JSON_NAME } + ": " + std::string{ stadium.GetName() } );
 		result.push_back( std::string{ CStadium::JSON_CAPACITY } + ": " + std::to_string( stadium.GetCapacity() ) );


### PR DESCRIPTION
Encapsulate interaction with json package in JsonUtils to maintain consistency in all the project.

Simplify concepts. Only keeping the nlohmann::json type and the SFINAE-related ones.

Use forward-declaration header in Jsonable types namespace. This, plus using a reference in the ToJSON method prevents including json.hpp in all the headers.