### PR TITLE
Protected class types

### DIFF
--- a/include/CPerson.h
+++ b/include/CPerson.h
@@ -12,8 +12,6 @@ namespace futsim
 */
 class CPerson : public IJsonable
 {
-	using json = IJsonableTypes::json;
-
 public:
 	/**
 	 * @brief Member constructor.

--- a/include/CPlayTime.h
+++ b/include/CPlayTime.h
@@ -12,6 +12,7 @@ namespace futsim
 */
 class CPlayTime : public IJsonable
 {
+protected:
 	using period_count = CPlayTimeTypes::period_count;
 	using period_time = CPlayTimeTypes::period_time;
 

--- a/include/CPlayTime.h
+++ b/include/CPlayTime.h
@@ -12,7 +12,6 @@ namespace futsim
 */
 class CPlayTime : public IJsonable
 {
-	using json = IJsonableTypes::json;
 	using period_count = CPlayTimeTypes::period_count;
 	using period_time = CPlayTimeTypes::period_time;
 

--- a/include/IJsonable.h
+++ b/include/IJsonable.h
@@ -10,6 +10,7 @@ namespace futsim
  */
 class IJsonable
 {
+protected:
 	using json = IJsonableTypes::json;
 
 public:

--- a/include/football/CExtraTime.h
+++ b/include/football/CExtraTime.h
@@ -13,8 +13,6 @@ namespace futsim::football
 class CExtraTime : public CPlayTime
 {
 	using subs_count = CPlayTimeTypes::subs_count;
-	using period_count = futsim::CPlayTimeTypes::period_count;
-	using period_time = futsim::CPlayTimeTypes::period_time;
 
 public:
 	/**

--- a/include/football/CExtraTime.h
+++ b/include/football/CExtraTime.h
@@ -12,7 +12,6 @@ namespace futsim::football
 */
 class CExtraTime : public CPlayTime
 {
-	using json = IJsonableTypes::json;
 	using subs_count = CPlayTimeTypes::subs_count;
 	using period_count = futsim::CPlayTimeTypes::period_count;
 	using period_time = futsim::CPlayTimeTypes::period_time;

--- a/include/football/CExtraTime.h
+++ b/include/football/CExtraTime.h
@@ -12,8 +12,6 @@ namespace futsim::football
 */
 class CExtraTime : public CPlayTime
 {
-	using subs_count = CPlayTimeTypes::subs_count;
-
 public:
 	/**
 	 * @copydoc futsim::football::CPlayTime::CPlayTime

--- a/include/football/CMatch.h
+++ b/include/football/CMatch.h
@@ -13,6 +13,7 @@ namespace futsim::football
 */
 class CMatch : public IJsonable
 {
+protected:
 	using name_type = CTeamTypes::name_type;
 
 public:

--- a/include/football/CMatch.h
+++ b/include/football/CMatch.h
@@ -13,7 +13,6 @@ namespace futsim::football
 */
 class CMatch : public IJsonable
 {
-	using json = IJsonableTypes::json;
 	using name_type = CTeamTypes::name_type;
 
 public:

--- a/include/football/CPenaltyShootoutConfiguration.h
+++ b/include/football/CPenaltyShootoutConfiguration.h
@@ -13,7 +13,6 @@ namespace futsim::football
 */
 class CPenaltyShootoutConfiguration : public IJsonable
 {
-	using json = IJsonableTypes::json;
 	using penalty_count = CPenaltyShootoutConfigurationTypes::penalty_count;
 
 public:

--- a/include/football/CPenaltyShootoutConfiguration.h
+++ b/include/football/CPenaltyShootoutConfiguration.h
@@ -13,6 +13,7 @@ namespace futsim::football
 */
 class CPenaltyShootoutConfiguration : public IJsonable
 {
+protected:
 	using penalty_count = CPenaltyShootoutConfigurationTypes::penalty_count;
 
 public:

--- a/include/football/CPlayTime.h
+++ b/include/football/CPlayTime.h
@@ -13,8 +13,6 @@ namespace futsim::football
 class CPlayTime : public futsim::CPlayTime
 {
 	using subs_count = CPlayTimeTypes::subs_count;
-	using period_count = futsim::CPlayTimeTypes::period_count;
-	using period_time = futsim::CPlayTimeTypes::period_time;
 
 public:
 	/**

--- a/include/football/CPlayTime.h
+++ b/include/football/CPlayTime.h
@@ -12,6 +12,7 @@ namespace futsim::football
 */
 class CPlayTime : public futsim::CPlayTime
 {
+protected:
 	using subs_count = CPlayTimeTypes::subs_count;
 
 public:

--- a/include/football/CPlayTime.h
+++ b/include/football/CPlayTime.h
@@ -12,7 +12,6 @@ namespace futsim::football
 */
 class CPlayTime : public futsim::CPlayTime
 {
-	using json = IJsonableTypes::json;
 	using subs_count = CPlayTimeTypes::subs_count;
 	using period_count = futsim::CPlayTimeTypes::period_count;
 	using period_time = futsim::CPlayTimeTypes::period_time;

--- a/include/football/CPlayer.h
+++ b/include/football/CPlayer.h
@@ -15,8 +15,6 @@ namespace football
 */
 class CPlayer : public CPerson
 {
-	using json = IJsonableTypes::json;
-
 public:
 	/**
 	 * @brief Member constructor.

--- a/include/football/CPlayerSkills.h
+++ b/include/football/CPlayerSkills.h
@@ -15,6 +15,7 @@ namespace football
 */
 class CPlayerSkills : public IJsonable
 {
+protected:
 	using skill_type = CPlayerSkillsTypes::skill_type;
 	using xp_type = CPlayerSkillsTypes::xp_type;
 

--- a/include/football/CPlayerSkills.h
+++ b/include/football/CPlayerSkills.h
@@ -15,7 +15,6 @@ namespace football
 */
 class CPlayerSkills : public IJsonable
 {
-	using json = IJsonableTypes::json;
 	using skill_type = CPlayerSkillsTypes::skill_type;
 	using xp_type = CPlayerSkillsTypes::xp_type;
 

--- a/include/football/CStadium.h
+++ b/include/football/CStadium.h
@@ -15,6 +15,7 @@ namespace football
 */
 class CStadium : public IJsonable
 {
+protected:
 	using capacity = CStadiumTypes::capacity;
 	using ambient_factor = CStadiumTypes::ambient_factor;
 

--- a/include/football/CStadium.h
+++ b/include/football/CStadium.h
@@ -15,7 +15,6 @@ namespace football
 */
 class CStadium : public IJsonable
 {
-	using json = IJsonableTypes::json;
 	using capacity = CStadiumTypes::capacity;
 	using ambient_factor = CStadiumTypes::ambient_factor;
 

--- a/include/football/CTeam.h
+++ b/include/football/CTeam.h
@@ -15,7 +15,6 @@ namespace futsim::football
 */
 class CTeam : public IJsonable
 {
-	using json = IJsonableTypes::json;
 	using name_type = CTeamTypes::name_type;
 	using players = CTeamTypes::players;
 	using support_factor = CTeamTypes::support_factor;

--- a/include/football/CTeam.h
+++ b/include/football/CTeam.h
@@ -15,6 +15,7 @@ namespace futsim::football
 */
 class CTeam : public IJsonable
 {
+protected:
 	using name_type = CTeamTypes::name_type;
 	using players = CTeamTypes::players;
 	using support_factor = CTeamTypes::support_factor;

--- a/include/football/CTieCondition.h
+++ b/include/football/CTieCondition.h
@@ -15,7 +15,6 @@ namespace futsim::football
 */
 class CTieCondition : public IJsonable
 {
-	using json = IJsonableTypes::json;
 	using goal_difference = CTieConditionTypes::goal_difference;
 	using goal_count = CTieConditionTypes::goal_count;
 	using optional_goal_count = CTieConditionTypes::optional_goal_count;

--- a/include/football/CTieCondition.h
+++ b/include/football/CTieCondition.h
@@ -15,6 +15,7 @@ namespace futsim::football
 */
 class CTieCondition : public IJsonable
 {
+protected:
 	using goal_difference = CTieConditionTypes::goal_difference;
 	using goal_count = CTieConditionTypes::goal_count;
 	using optional_goal_count = CTieConditionTypes::optional_goal_count;


### PR DESCRIPTION
Aliased defined in classes are change from private to protected so that they can be reused by derived classes.
Resolves #91 