### PR TITLE
Add default keep possession probability

### DIFF
--- a/include/football/CPossessionDrawConfiguration.h
+++ b/include/football/CPossessionDrawConfiguration.h
@@ -43,6 +43,8 @@ public:
 	static inline constexpr std::string_view JSON_KEY = "Possession draw configuration";
 	//! JSON key for the \copybrief mKeepPossessionProbability
 	static inline constexpr std::string_view JSON_KEEP_POSSESSION_PROBABILITY = "Keep possession probability";
+	//! Default keep posssession probability.
+	static inline constexpr probability DEFAULT_KEEP_POSSESSION_PROBABILITY = probability{ 295952 } / 460939;
 
 private:
 	//! Center probability to keep possession.

--- a/include/football/CPossessionDrawConfiguration.h
+++ b/include/football/CPossessionDrawConfiguration.h
@@ -21,7 +21,7 @@ public:
 	 * @param aKeepPossessionProbability \ref mKeepPossessionProbability
 	*/
 	explicit CPossessionDrawConfiguration(
-		const probability& aKeepPossessionProbability );
+		const probability& aKeepPossessionProbability = DEFAULT_KEEP_POSSESSION_PROBABILITY );
 
 	/**
 	 * @brief JSON constructor.

--- a/src/football/CPossessionDrawConfiguration.cpp
+++ b/src/football/CPossessionDrawConfiguration.cpp
@@ -16,7 +16,8 @@ CPossessionDrawConfiguration::CPossessionDrawConfiguration(
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the possession draw configuration." )
 
 CPossessionDrawConfiguration::CPossessionDrawConfiguration( const json& aJSON ) try :
-	mKeepPossessionProbability( CheckProbability( ValueFromRequiredJSONKey<probability>( aJSON, JSON_KEEP_POSSESSION_PROBABILITY ), "probability to keep possession" ) )
+	mKeepPossessionProbability( CheckProbability( ValueFromOptionalJSONKey<probability>(
+		aJSON, JSON_KEEP_POSSESSION_PROBABILITY, DEFAULT_KEEP_POSSESSION_PROBABILITY ), "probability to keep possession" ) )
 {
 }
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the possession draw configuration from JSON." )

--- a/tests/unit/football/TPossessionDrawConfiguration.cpp
+++ b/tests/unit/football/TPossessionDrawConfiguration.cpp
@@ -19,9 +19,6 @@ void TPossessionDrawConfiguration::TestExceptions() const
 
 	// Test JSON constructor
 	CheckException( []() { futsim::ValueFromJSONKeyString<CPossessionDrawConfiguration>( R"( {
-			"Possession draw configuration": {}
-		} )" ); }, "key 'Keep possession probability' not found" );
-	CheckException( []() { futsim::ValueFromJSONKeyString<CPossessionDrawConfiguration>( R"( {
 			"Possession draw configuration": {
 				"Keep possession probability": -2
 			}
@@ -37,10 +34,16 @@ std::vector<std::string> TPossessionDrawConfiguration::ObtainedResults() const n
 {
 	std::vector<std::string> result;
 	for( const auto& possessionDrawConfiguration : {
-		CPossessionDrawConfiguration{ 295952.0 / 460939.0 },
+		CPossessionDrawConfiguration{},
+		CPossessionDrawConfiguration{ 0.6 },
 		futsim::ValueFromJSONKeyString<CPossessionDrawConfiguration>( R"( {
 			"Possession draw configuration": {
 				"Keep possession probability": 0.6420632665059802
+			}
+		} )" ),
+		futsim::ValueFromJSONKeyString<CPossessionDrawConfiguration>( R"( {
+			"Possession draw configuration": {
+				"Keep possession probability": 0.6
 			}
 		} )" ) } )
 	{
@@ -59,6 +62,12 @@ std::vector<std::string> TPossessionDrawConfiguration::ExpectedResults() const n
 		"{\n"
 		"	\"Possession draw configuration\": {\n"
 		"		\"Keep possession probability\": 0.6420632665059802\n"
+		"	}\n"
+		"}",
+		"Keep possession probability: 0.600000",
+		"{\n"
+		"	\"Possession draw configuration\": {\n"
+		"		\"Keep possession probability\": 0.6\n"
 		"	}\n"
 		"}"
 	};


### PR DESCRIPTION
Configurations must have a default constructor. In this case, the default corresponds to a probability obtained from Premier League data