### PR TITLE
Add static default values

### DIFF
--- a/include/football/CExtraTime.h
+++ b/include/football/CExtraTime.h
@@ -18,10 +18,10 @@ public:
 	 * @param aGoalRule \ref mGoalRule
 	*/
 	explicit CExtraTime(
-		const period_count& aPeriodCount = 2,
-		const period_time& aPeriodTime = 15,
-		const subs_count& aAvailableSubs = 1,
-		const E_GOAL_RULE& aGoalRule = E_GOAL_RULE::NO );
+		const period_count& aPeriodCount = DEFAULT_PERIOD_COUNT,
+		const period_time& aPeriodTime = DEFAULT_PERIOD_TIME,
+		const subs_count& aAvailableSubs = DEFAULT_AVAILABLE_SUBS,
+		const E_GOAL_RULE& aGoalRule = DEFAULT_GOAL_RULE );
 
 	/**
 	 * @brief JSON constructor.
@@ -43,6 +43,13 @@ public:
 	static inline constexpr std::string_view JSON_KEY = "Extra time";
 	//! JSON key for the \copybrief mGoalRule
 	static inline constexpr std::string_view JSON_GOAL_RULE = "Goal rule";
+
+	//! Default \copybrief mPeriodTime
+	static inline constexpr period_count DEFAULT_PERIOD_TIME = 15;
+	//! Default \copybrief mAvailableSubs
+	static inline constexpr subs_count DEFAULT_AVAILABLE_SUBS = 1;
+	//! Default \copybrief mGoalRule
+	static inline constexpr E_GOAL_RULE DEFAULT_GOAL_RULE = E_GOAL_RULE::NO;
 
 private:
 	//! Goal rule.

--- a/include/football/CMatchConfiguration.h
+++ b/include/football/CMatchConfiguration.h
@@ -36,8 +36,8 @@ public:
 	*/
 	explicit CMatchConfiguration(
 		const CPlayTime& aPlayTime = CPlayTime{},
-		const benched_count& aBenchedPlayersCount = 9,
-		const bool aApplyAmbientFactor = true,
+		const benched_count& aBenchedPlayersCount = DEFAULT_BENCHED_PLAYERS,
+		const bool aApplyAmbientFactor = DEFAULT_APPLY_AMBIENT_FACTOR,
 		const optional_tie_condition& aTieCondition = {},
 		const optional_extra_time& aExtraTime = {},
 		const optional_penalty_shootout_configuration& aPenaltyShootoutConfiguration = {},
@@ -83,6 +83,11 @@ public:
 	static inline constexpr std::string_view JSON_BENCHED_PLAYERS = "Benched players";
 	//! JSON key for the \copybrief mApplyAmbientFactor
 	static inline constexpr std::string_view JSON_APPLY_AMBIENT_FACTOR = "Apply ambient factor";
+
+	//! Default \copybrief mBenchedPlayersCount
+	static inline constexpr benched_count DEFAULT_BENCHED_PLAYERS = 9;
+	//! Default \copybrief mApplyAmbientFactor
+	static inline constexpr bool DEFAULT_APPLY_AMBIENT_FACTOR = true;
 
 private:
 	//! Play time configuration.

--- a/include/football/CPenaltyShootoutConfiguration.h
+++ b/include/football/CPenaltyShootoutConfiguration.h
@@ -23,8 +23,8 @@ public:
 	 * @param aMinPenaltyCount \ref mMinPenaltyCount
 	*/
 	explicit CPenaltyShootoutConfiguration(
-		const E_PENALTY_SEQUENCE& aPenaltySequence = E_PENALTY_SEQUENCE::AB,
-		const penalty_count& aMinPenaltyCount = 5 ) noexcept;
+		const E_PENALTY_SEQUENCE& aPenaltySequence = DEFAULT_PENALTY_SEQUENCE,
+		const penalty_count& aMinPenaltyCount = DEFAULT_PENALTY_COUNT ) noexcept;
 
 	/**
 	 * @brief JSON constructor.
@@ -51,6 +51,12 @@ public:
 	static inline constexpr std::string_view JSON_SEQUENCE = "Sequence";
 	//! JSON key for the \copybrief mMinPenaltyCount
 	static inline constexpr std::string_view JSON_MIN_PENALTY_COUNT = "Min penalty count";
+
+	//! Default \copybrief mPenaltySequence
+	static inline constexpr E_PENALTY_SEQUENCE DEFAULT_PENALTY_SEQUENCE = E_PENALTY_SEQUENCE::AB;
+
+	//! Default \copybrief mMinPenaltyCount
+	static inline constexpr penalty_count DEFAULT_PENALTY_COUNT = 5;
 
 private:
 	//! Penalty sequence.

--- a/include/football/CPlayTime.h
+++ b/include/football/CPlayTime.h
@@ -21,9 +21,9 @@ public:
 	 * @param aAvailableSubs \ref mAvailableSubs
 	*/
 	explicit CPlayTime(
-		const period_count& aPeriodCount = 2,
-		const period_time& aPeriodTime = 45,
-		const subs_count& aAvailableSubs = 5 );
+		const period_count& aPeriodCount = DEFAULT_PERIOD_COUNT,
+		const period_time& aPeriodTime = DEFAULT_PERIOD_TIME,
+		const subs_count& aAvailableSubs = DEFAULT_AVAILABLE_SUBS );
 
 	/**
 	 * @brief JSON constructor.
@@ -43,6 +43,13 @@ public:
 
 	//! JSON key for the \copybrief mAvailableSubs
 	static inline constexpr std::string_view JSON_AVAILABLE_SUBS = "Available subs";
+
+	//! Default \copybrief mPeriodCount
+	static inline constexpr period_count DEFAULT_PERIOD_COUNT = 2;
+	//! Default \copybrief mPeriodTime
+	static inline constexpr period_count DEFAULT_PERIOD_TIME = 45;
+	//! Default \copybrief mAvailableSubs
+	static inline constexpr subs_count DEFAULT_AVAILABLE_SUBS = 5;
 
 private:
 	//! Number of available subs.

--- a/include/football/CTieCondition.h
+++ b/include/football/CTieCondition.h
@@ -27,7 +27,7 @@ public:
 	 * @param aHomeTeamGoals \ref mHomeTeamGoals
 	*/
 	explicit CTieCondition(
-		const goal_difference aHomeTeamLead = 0,
+		const goal_difference aHomeTeamLead = goal_difference{},
 		const optional_goal_count& aHomeTeamGoals = {} );
 
 	/**

--- a/src/football/CExtraTime.cpp
+++ b/src/football/CExtraTime.cpp
@@ -19,8 +19,10 @@ CExtraTime::CExtraTime(
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the football extra time." )
 
 CExtraTime::CExtraTime( const json& aJSON ) try :
-	CPlayTime( aJSON ),
-	mGoalRule( ValueFromOptionalJSONKey<E_GOAL_RULE>( aJSON, JSON_GOAL_RULE, E_GOAL_RULE::NO ) )
+	CPlayTime( ValueFromOptionalJSONKey<period_count>( aJSON, JSON_PERIOD_COUNT, DEFAULT_PERIOD_COUNT ),
+		ValueFromOptionalJSONKey<period_time>( aJSON, JSON_PERIOD_TIME, DEFAULT_PERIOD_TIME ),
+		ValueFromOptionalJSONKey<subs_count>( aJSON, JSON_AVAILABLE_SUBS, DEFAULT_AVAILABLE_SUBS ) ),
+	mGoalRule( ValueFromOptionalJSONKey<E_GOAL_RULE>( aJSON, JSON_GOAL_RULE, DEFAULT_GOAL_RULE ) )
 {
 }
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the football extra time from JSON." )
@@ -28,7 +30,7 @@ FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the f
 void CExtraTime::JSON( json& aJSON ) const noexcept
 {
 	CPlayTime::JSON( aJSON );
-	if( mGoalRule != E_GOAL_RULE::NO )
+	if( mGoalRule != DEFAULT_GOAL_RULE )
 		AddToJSONKey( aJSON, mGoalRule, JSON_GOAL_RULE );
 }
 

--- a/src/football/CMatchConfiguration.cpp
+++ b/src/football/CMatchConfiguration.cpp
@@ -42,8 +42,8 @@ FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the m
 
 CMatchConfiguration::CMatchConfiguration( const json& aJSON ) try :
 	mPlayTime( ValueFromRequiredJSONKey<CPlayTime>( aJSON ) ),
-	mBenchedPlayersCount( ValueFromOptionalJSONKey<benched_count>( aJSON, JSON_BENCHED_PLAYERS, {} ) ),
-	mApplyAmbientFactor( ValueFromRequiredJSONKey<bool>( aJSON, JSON_APPLY_AMBIENT_FACTOR ) ),
+	mBenchedPlayersCount( ValueFromOptionalJSONKey<benched_count>( aJSON, JSON_BENCHED_PLAYERS ) ),
+	mApplyAmbientFactor( ValueFromOptionalJSONKey<bool>( aJSON, JSON_APPLY_AMBIENT_FACTOR, DEFAULT_APPLY_AMBIENT_FACTOR ) ),
 	mTieCondition( ValueFromOptionalJSONKey<optional_tie_condition>( aJSON, CTieCondition::JSON_KEY, {} ) ),
 	mExtraTime( ValueFromOptionalJSONKey<optional_extra_time>( aJSON, CExtraTime::JSON_KEY, {} ) ),
 	mPenaltyShootoutConfiguration( ValueFromOptionalJSONKey<optional_penalty_shootout_configuration>( aJSON, CPenaltyShootoutConfiguration::JSON_KEY, {} ) ),

--- a/src/football/CPenaltyShootoutConfiguration.cpp
+++ b/src/football/CPenaltyShootoutConfiguration.cpp
@@ -16,8 +16,8 @@ CPenaltyShootoutConfiguration::CPenaltyShootoutConfiguration(
 }
 
 CPenaltyShootoutConfiguration::CPenaltyShootoutConfiguration( const json& aJSON ) try :
-	mPenaltySequence( ValueFromRequiredJSONKey<E_PENALTY_SEQUENCE>( aJSON, JSON_SEQUENCE ) ),
-	mMinPenaltyCount( ValueFromRequiredJSONKey<penalty_count>( aJSON, JSON_MIN_PENALTY_COUNT ) )
+	mPenaltySequence( ValueFromOptionalJSONKey<E_PENALTY_SEQUENCE>( aJSON, JSON_SEQUENCE, DEFAULT_PENALTY_SEQUENCE ) ),
+	mMinPenaltyCount( ValueFromOptionalJSONKey<penalty_count>( aJSON, JSON_MIN_PENALTY_COUNT, DEFAULT_PENALTY_COUNT ) )
 {
 }
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the penalty shootout configuration from JSON." )

--- a/src/football/CPlayTime.cpp
+++ b/src/football/CPlayTime.cpp
@@ -18,7 +18,8 @@ CPlayTime::CPlayTime(
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the football play time." )
 
 CPlayTime::CPlayTime( const json& aJSON ) try :
-	futsim::CPlayTime( aJSON ),
+	futsim::CPlayTime( ValueFromOptionalJSONKey<period_count>( aJSON, JSON_PERIOD_COUNT, DEFAULT_PERIOD_COUNT ),
+		ValueFromOptionalJSONKey<period_time>( aJSON, JSON_PERIOD_TIME, DEFAULT_PERIOD_TIME ) ),
 	mAvailableSubs( ValueFromOptionalJSONKey<subs_count>( aJSON, JSON_AVAILABLE_SUBS ) )
 {
 }

--- a/src/football/CTieCondition.cpp
+++ b/src/football/CTieCondition.cpp
@@ -43,7 +43,7 @@ CTieCondition::CTieCondition(
 }
 
 CTieCondition::CTieCondition( const json& aJSON ) try :
-	mHomeTeamLead( ValueFromRequiredJSONKey<goal_difference>( aJSON, JSON_HOME_TEAM_LEAD ) ),
+	mHomeTeamLead( ValueFromOptionalJSONKey<goal_difference>( aJSON, JSON_HOME_TEAM_LEAD ) ),
 	mHomeTeamGoals( CheckHomeTeamGoals( ValueFromOptionalJSONKey<optional_goal_count>( aJSON, JSON_HOME_TEAM_GOALS ), mHomeTeamLead ) )
 {
 }

--- a/tests/unit/football/TMatchConfiguration.cpp
+++ b/tests/unit/football/TMatchConfiguration.cpp
@@ -24,15 +24,6 @@ void TMatchConfiguration::TestExceptions() const
 					"Period count": 2,
 					"Period time": 45,
 					"Available subs": 5
-				}
-			}
-		} )" ); }, "key 'Apply ambient factor' not found" );
-	CheckException( []() { futsim::ValueFromJSONKeyString<CMatchConfiguration>( R"( {
-			"Match configuration": {
-				"Play time": {
-					"Period count": 2,
-					"Period time": 45,
-					"Available subs": 5
 				},
 				"Apply ambient factor": true,
 				"Tie condition": {

--- a/tests/unit/football/TPenaltyShootoutConfiguration.cpp
+++ b/tests/unit/football/TPenaltyShootoutConfiguration.cpp
@@ -13,15 +13,6 @@ INITIALIZE_TEST( TPenaltyShootoutConfiguration )
 
 void TPenaltyShootoutConfiguration::TestExceptions() const
 {
-	// Test JSON constructor.
-	CheckException( []() { futsim::ValueFromJSONKeyString<CPenaltyShootoutConfiguration>( R"( {
-			"Penalty shootout configuration": {}
-		} )" ); }, "key 'Sequence' not found" );
-	CheckException( []() { futsim::ValueFromJSONKeyString<CPenaltyShootoutConfiguration>( R"( {
-			"Penalty shootout configuration": {
-				"Sequence": "AB"
-			}
-		} )" ); }, "key 'Min penalty count' not found" );
 }
 
 std::vector<std::string> TPenaltyShootoutConfiguration::ObtainedResults() const noexcept

--- a/tests/unit/football/TTieCondition.cpp
+++ b/tests/unit/football/TTieCondition.cpp
@@ -18,9 +18,6 @@ void TTieCondition::TestExceptions() const
 
 	// Test JSON constructor.
 	CheckException( []() { futsim::ValueFromJSONKeyString<CTieCondition>( R"( {
-			"Tie condition": {}
-		} )" ); }, "key 'Home team lead' not found" );
-	CheckException( []() { futsim::ValueFromJSONKeyString<CTieCondition>( R"( {
 			"Tie condition": {
 				"Home team lead" : 5,
 				"Home team goals": 1


### PR DESCRIPTION
Provide non-trivial default values as static members of the class, avoiding repetition.

Also, more consistency is provided between member and JSON constructor making more keys optional.