### PR TITLE
Use std::span in getters whenever possible

### DIFF
--- a/include/football/CLineup.h
+++ b/include/football/CLineup.h
@@ -40,10 +40,10 @@ public:
 	 * @brief Retrieves the players at a certain position.
 	 * @param aPlayerPosition Position.
 	*/
-	const names& GetPlayers( const E_PLAYER_POSITION& aPlayerPosition ) const noexcept;
+	std::span<const names::value_type> GetPlayers( const E_PLAYER_POSITION& aPlayerPosition ) const noexcept;
 
 	//! Retrieves the substitute players.
-	const names& GetSubs() const noexcept;
+	std::span<const names::value_type> GetSubs() const noexcept;
 
 	//! JSON key for the class.
 	static inline constexpr std::string_view JSON_KEY = "Lineup";

--- a/include/football/CTeam.h
+++ b/include/football/CTeam.h
@@ -71,7 +71,7 @@ public:
 	std::string_view GetManager() const noexcept;
 
 	//! Retrieves the \copybrief mPlayers
-	const players& GetPlayers() const noexcept;
+	std::span<const CPlayer> GetPlayers() const noexcept;
 
 	//! Retrieves the \copybrief mSupportFactor
 	const support_factor& GetSupportFactor() const noexcept;

--- a/src/football/CLineup.cpp
+++ b/src/football/CLineup.cpp
@@ -45,12 +45,12 @@ void CLineup::JSON( json& aJSON ) const noexcept
 		AddToJSONKey( aJSON, players, JSON_SUBS );
 }
 
-const CLineup::names& CLineup::GetPlayers( const E_PLAYER_POSITION& aPlayerPosition ) const noexcept
+std::span<const CLineup::names::value_type> CLineup::GetPlayers( const E_PLAYER_POSITION& aPlayerPosition ) const noexcept
 {
 	return mPlayersLineup[ static_cast< position_names::size_type >( aPlayerPosition ) ];
 }
 
-const CLineup::names& CLineup::GetSubs() const noexcept
+std::span<const CLineup::names::value_type> CLineup::GetSubs() const noexcept
 {
 	return mPlayersLineup.back();
 }

--- a/src/football/CTeam.cpp
+++ b/src/football/CTeam.cpp
@@ -106,7 +106,7 @@ std::string_view CTeam::GetManager() const noexcept
 	return mManager;
 }
 
-const CTeam::players& CTeam::GetPlayers() const noexcept
+std::span<const CPlayer> CTeam::GetPlayers() const noexcept
 {
 	return mPlayers;
 }


### PR DESCRIPTION
It is not used in the constructors since `std::ranges::to` is added in C++23, and it's not worth dirtying the constructors to create the container from the span