### PR TITLE
Fix enum distribution operator()

### DIFF
--- a/include/CEnumDistribution.h
+++ b/include/CEnumDistribution.h
@@ -63,14 +63,14 @@ template <typename tEnumType, typename tIntType>
 typename CEnumDistribution<tEnumType, tIntType>::result_type CEnumDistribution<tEnumType, tIntType>::operator()
 ( std::uniform_random_bit_generator auto& aGenerator )
 {
-	return static_cast< result_type >( std::discrete_distribution<tIntType>( aGenerator ) );
+	return static_cast< result_type >( std::discrete_distribution<tIntType>::operator()( aGenerator ) );
 }
 
 template <typename tEnumType, typename tIntType>
 typename CEnumDistribution<tEnumType, tIntType>::result_type CEnumDistribution<tEnumType, tIntType>::operator()
 ( std::uniform_random_bit_generator auto& aGenerator, const param_type& aParams )
 {
-	return static_cast< result_type >( std::discrete_distribution<tIntType>( aGenerator, aParams ) );
+	return static_cast< result_type >( std::discrete_distribution<tIntType>::operator()( aGenerator, aParams ) );
 }
 
 template <typename tEnumType, typename tIntType>

--- a/tests/unit/TEnumDistribution.cpp
+++ b/tests/unit/TEnumDistribution.cpp
@@ -35,8 +35,9 @@ std::vector<std::string> TEnumDistribution::ObtainedResults() const noexcept
 	std::vector<std::string> result;
 
 	const std::array<double, 3> weightArray{ 1, 1, 1 };
+	std::mt19937 rng{ 1234 };
 
-	for( const auto& enumDistribution : {
+	for( auto enumDistribution : {
 		CEnumDistribution<myEnum>{},
 		CEnumDistribution<myEnum>{ weightArray.cbegin(), weightArray.cend() },
 		CEnumDistribution<myEnum>{ { 1, 2, 3 } },
@@ -49,7 +50,8 @@ std::vector<std::string> TEnumDistribution::ObtainedResults() const noexcept
 		result.push_back( "Probabilities:" );
 		for( const auto& probability : enumDistribution.probabilities() )
 			result.push_back( std::to_string( probability ) );
-
+		enumDistribution( rng );
+		enumDistribution( rng, enumDistribution.param() );
 	}
 	return result;
 }


### PR DESCRIPTION
Fixed bug in which instead of calling operator() a cast was being made