### PR TITLE
Drop clang testing

### DIFF
--- a/.github/workflows/test-multi-platform.yml
+++ b/.github/workflows/test-multi-platform.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         config:
           - { os: ubuntu-latest, build_type: "Release", c_compiler: "gcc", cpp_compiler: "g++" }
-          - { os: ubuntu-latest, build_type: "Release", c_compiler: "clang", cpp_compiler: "clang++" }
+          # - { os: ubuntu-latest, build_type: "Release", c_compiler: "clang", cpp_compiler: "clang++" }
           - { os: windows-latest, build_type: "Release", c_compiler: "cl", cpp_compiler: "cl" }
 
     steps:

--- a/include/CEnumDistribution.h
+++ b/include/CEnumDistribution.h
@@ -19,7 +19,7 @@ public:
 	//! Type for the result.
 	using result_type = tEnumType;
 	//! Type for the distribution parameters.
-	using param_type = typename std::discrete_distribution<tIntType>::param_type;
+	using param_type = std::discrete_distribution<tIntType>::param_type;
 
 	/**
 	 * @name Constructs a new distribution object
@@ -60,27 +60,27 @@ public:
 };
 
 template <typename tEnumType, typename tIntType>
-typename CEnumDistribution<tEnumType, tIntType>::result_type CEnumDistribution<tEnumType, tIntType>::operator()
+CEnumDistribution<tEnumType, tIntType>::result_type CEnumDistribution<tEnumType, tIntType>::operator()
 ( std::uniform_random_bit_generator auto& aGenerator )
 {
 	return static_cast< result_type >( std::discrete_distribution<tIntType>::operator()( aGenerator ) );
 }
 
 template <typename tEnumType, typename tIntType>
-typename CEnumDistribution<tEnumType, tIntType>::result_type CEnumDistribution<tEnumType, tIntType>::operator()
+CEnumDistribution<tEnumType, tIntType>::result_type CEnumDistribution<tEnumType, tIntType>::operator()
 ( std::uniform_random_bit_generator auto& aGenerator, const param_type& aParams )
 {
 	return static_cast< result_type >( std::discrete_distribution<tIntType>::operator()( aGenerator, aParams ) );
 }
 
 template <typename tEnumType, typename tIntType>
-typename CEnumDistribution<tEnumType, tIntType>::result_type CEnumDistribution<tEnumType, tIntType>::min() const
+CEnumDistribution<tEnumType, tIntType>::result_type CEnumDistribution<tEnumType, tIntType>::min() const
 {
 	return static_cast< result_type >( std::discrete_distribution<tIntType>::min() );
 }
 
 template <typename tEnumType, typename tIntType>
-typename CEnumDistribution<tEnumType, tIntType>::result_type CEnumDistribution<tEnumType, tIntType>::max() const
+CEnumDistribution<tEnumType, tIntType>::result_type CEnumDistribution<tEnumType, tIntType>::max() const
 {
 	return static_cast< result_type >( std::discrete_distribution<tIntType>::max() );
 }


### PR DESCRIPTION
Drops clang testing via github actions because the current version used is missing too many c++20 features.

Resolves #147 .