### PR TITLE
Add extra time period state

### DIFF
--- a/FileList.cmake
+++ b/FileList.cmake
@@ -23,6 +23,7 @@ SET(FUTSIM_FOOTBALL_EXTERNAL_HEADERS
 	include/football/CChanceState.h
 	include/football/CDrawConfiguration.h
 	include/football/CExtraTime.h
+	include/football/CExtraTimePeriodState.h
 	include/football/CFoulDrawConfiguration.h
 	include/football/CFoulState.h
 	include/football/CGoalDrawConfiguration.h
@@ -87,6 +88,7 @@ SET(FUTSIM_FOOTBALL_SOURCE
 	src/football/CChanceState.cpp
 	src/football/CDrawConfiguration.cpp
 	src/football/CExtraTime.cpp
+	src/football/CExtraTimePeriodState.cpp
 	src/football/CFoulDrawConfiguration.cpp
 	src/football/CFoulState.cpp
 	src/football/CGoalDrawConfiguration.cpp

--- a/include/football/CExtraTimePeriodState.h
+++ b/include/football/CExtraTimePeriodState.h
@@ -62,12 +62,6 @@ public:
 	);
 
 	/**
-	 * @brief Returns whether a goal has been scored in the last play.
-	 * @pre At least one play must have been occurred.
-	*/
-	bool HasGoalBeenScoredLast() const;
-
-	/**
 	 * @brief Checks that the match configuration can produce an extra time period.
 	 * @param aMatchConfiguration Match configuration.
 	*/
@@ -82,19 +76,10 @@ CExtraTimePeriodState::CExtraTimePeriodState(
 	bool aHomeTeamAttack,
 	std::uniform_random_bit_generator auto& aGenerator
 ) try :
-	CPeriodState( aMatchConfiguration.GetExtraTime()->GetPeriodTime() )
+	CPeriodState( aMatchConfiguration.GetExtraTime()->GetGoalRule() == E_GOAL_RULE::GOLDEN_GOAL ?
+		CPeriodState{ aMatch, aMatchConfiguration, aHomeTeamStrategy, aAwayTeamStrategy, aHomeTeamAttack, aGenerator, SGoldenGoalPeriodPlayPolicy{} } :
+		CPeriodState{ aMatch, aMatchConfiguration, aHomeTeamStrategy, aAwayTeamStrategy, aHomeTeamAttack, aGenerator, SDefaultPeriodPlayPolicy{} } )
 {
-	const auto& extraTime = *aMatchConfiguration.GetExtraTime();
-	do
-	{
-		if( aHomeTeamAttack )
-			PushPlayState( CPlayState{ aMatch, aMatchConfiguration, aHomeTeamStrategy, aAwayTeamStrategy,
-				aHomeTeamAttack, aGenerator }, aHomeTeamAttack );
-		else
-			PushPlayState( CPlayState{ aMatch, aMatchConfiguration, aAwayTeamStrategy, aHomeTeamStrategy,
-				aHomeTeamAttack, aGenerator }, aHomeTeamAttack );
-		aHomeTeamAttack = IsHomeTeamAttackNext();
-	} while( GetPlays().size() < extraTime.GetPeriodTime() && ( extraTime.GetGoalRule() != E_GOAL_RULE::GOLDEN_GOAL || !HasGoalBeenScoredLast() ) );
 }
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the extra time period state." )
 

--- a/include/football/CExtraTimePeriodState.h
+++ b/include/football/CExtraTimePeriodState.h
@@ -14,6 +14,20 @@ class CExtraTimePeriodState : public CPeriodState
 {
 public:
 	/**
+	 * @brief Default policy functor for the plays of an extra time period.
+	 * @details All configured minutes are played.
+	*/
+	struct SDefaultPeriodPlayPolicy
+	{
+		/**
+		 * @brief Returns whether another minute must be played.
+		 * @param aPlays Plays of the period.
+		 * @param aMatchConfiguration Match configuration.
+		*/
+		bool operator()( const plays& aPlays, const CMatchConfiguration& aMatchConfiguration ) const;
+	};
+
+	/**
 	 * @brief Constructor from the match definition, configuration and current strategies.
 	 * @param aMatch Match definition.
 	 * @param aMatchConfiguration Match configuration.

--- a/include/football/CExtraTimePeriodState.h
+++ b/include/football/CExtraTimePeriodState.h
@@ -61,6 +61,13 @@ public:
 		std::uniform_random_bit_generator auto& aGenerator
 	);
 
+protected:
+	/**
+	 * @copydoc IJsonable::ToJSON
+	*/
+	void JSON( json& aJSON ) const noexcept override;
+
+public:
 	/**
 	 * @brief Checks that the match configuration can produce an extra time period.
 	 * @param aMatchConfiguration Match configuration.

--- a/include/football/CExtraTimePeriodState.h
+++ b/include/football/CExtraTimePeriodState.h
@@ -28,6 +28,20 @@ public:
 	};
 
 	/**
+	 * @brief Policy functor for the plays of an extra time period with golden goal.
+	 * @details Period also ends when a goal is scored.
+	*/
+	struct SGoldenGoalPeriodPlayPolicy : public SDefaultPeriodPlayPolicy
+	{
+		/**
+		 * @brief Returns whether another minute must be played.
+		 * @param aPlays Plays of the period.
+		 * @param aMatchConfiguration Match configuration.
+		*/
+		bool operator()( const plays& aPlays, const CMatchConfiguration& aMatchConfiguration ) const;
+	};
+
+	/**
 	 * @brief Constructor from the match definition, configuration and current strategies.
 	 * @param aMatch Match definition.
 	 * @param aMatchConfiguration Match configuration.

--- a/include/football/CExtraTimePeriodState.h
+++ b/include/football/CExtraTimePeriodState.h
@@ -66,6 +66,9 @@ public:
 	 * @param aMatchConfiguration Match configuration.
 	*/
 	static const CMatchConfiguration& CheckMatchConfiguration( const CMatchConfiguration& aMatchConfiguration );
+
+	//! JSON key for the class.
+	static inline constexpr std::string_view JSON_KEY = "Extra time period state";
 };
 
 CExtraTimePeriodState::CExtraTimePeriodState(

--- a/include/football/CExtraTimePeriodState.h
+++ b/include/football/CExtraTimePeriodState.h
@@ -22,6 +22,7 @@ public:
 	 * @param aHomeTeamAttack Whether the home team is attacking.
 	 * @param aGenerator RNG to use.
 	 * @pre The team strategies must both pass \ref CMatchConfiguration::CheckTeamStrategy and \ref CMatch::CheckTeamStrategy
+	 * @pre The match configuration must pass \ref CheckMatchConfiguration
 	*/
 	explicit CExtraTimePeriodState(
 		const CMatch& aMatch,
@@ -31,6 +32,42 @@ public:
 		bool aHomeTeamAttack,
 		std::uniform_random_bit_generator auto& aGenerator
 	);
+
+	/**
+	 * @brief Returns whether a goal has been scored in the last play.
+	 * @pre At least one play must have been occurred.
+	*/
+	bool HasGoalBeenScoredLast() const;
+
+	/**
+	 * @brief Checks that the match configuration can produce an extra time period.
+	 * @param aMatchConfiguration Match configuration.
+	*/
+	static const CMatchConfiguration& CheckMatchConfiguration( const CMatchConfiguration& aMatchConfiguration );
 };
+
+CExtraTimePeriodState::CExtraTimePeriodState(
+	const CMatch& aMatch,
+	const CMatchConfiguration& aMatchConfiguration,
+	const CTeamStrategy& aHomeTeamStrategy,
+	const CTeamStrategy& aAwayTeamStrategy,
+	bool aHomeTeamAttack,
+	std::uniform_random_bit_generator auto& aGenerator
+) try :
+	CPeriodState( aMatchConfiguration.GetExtraTime()->GetPeriodTime() )
+{
+	const auto& extraTime = *aMatchConfiguration.GetExtraTime();
+	do
+	{
+		if( aHomeTeamAttack )
+			PushPlayState( CPlayState{ aMatch, aMatchConfiguration, aHomeTeamStrategy, aAwayTeamStrategy,
+				aHomeTeamAttack, aGenerator }, aHomeTeamAttack );
+		else
+			PushPlayState( CPlayState{ aMatch, aMatchConfiguration, aAwayTeamStrategy, aHomeTeamStrategy,
+				aHomeTeamAttack, aGenerator }, aHomeTeamAttack );
+		aHomeTeamAttack = IsHomeTeamAttackNext();
+	} while( GetPlays().size() < extraTime.GetPeriodTime() && ( extraTime.GetGoalRule() != E_GOAL_RULE::GOLDEN_GOAL || !HasGoalBeenScoredLast() ) );
+}
+FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the extra time period state." )
 
 } // futsim::football namespace

--- a/include/football/CExtraTimePeriodState.h
+++ b/include/football/CExtraTimePeriodState.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "IJsonable.h"
+
+#include "football/CPeriodState.h"
+
+namespace futsim::football
+{
+
+/**
+ * @brief Class that represents the state of an extra time match period.
+*/
+class CExtraTimePeriodState : public CPeriodState
+{
+public:
+	/**
+	 * @brief Constructor from the match definition, configuration and current strategies.
+	 * @param aMatch Match definition.
+	 * @param aMatchConfiguration Match configuration.
+	 * @param aHomeTeamStrategy Current match strategy for the home team.
+	 * @param aAwayTeamStrategy Current match strategy for the away team.
+	 * @param aHomeTeamAttack Whether the home team is attacking.
+	 * @param aGenerator RNG to use.
+	 * @pre The team strategies must both pass \ref CMatchConfiguration::CheckTeamStrategy and \ref CMatch::CheckTeamStrategy
+	*/
+	explicit CExtraTimePeriodState(
+		const CMatch& aMatch,
+		const CMatchConfiguration& aMatchConfiguration,
+		const CTeamStrategy& aHomeTeamStrategy,
+		const CTeamStrategy& aAwayTeamStrategy,
+		bool aHomeTeamAttack,
+		std::uniform_random_bit_generator auto& aGenerator
+	);
+};
+
+} // futsim::football namespace

--- a/include/football/CPeriodState.h
+++ b/include/football/CPeriodState.h
@@ -39,6 +39,14 @@ public:
 
 protected:
 	/**
+	 * @brief Empty period constructor.
+	 * @param aPeriodTime Play time of the period.
+	*/
+	explicit CPeriodState(
+		const futsim::types::CPlayTime::period_time& aPeriodTime
+	);
+
+	/**
 	 * @copydoc IJsonable::ToJSON
 	*/
 	void JSON( json& aJSON ) const noexcept override;

--- a/include/football/CPeriodState.h
+++ b/include/football/CPeriodState.h
@@ -57,14 +57,6 @@ public:
 
 protected:
 	/**
-	 * @brief Empty period constructor.
-	 * @param aPeriodTime Play time of the period.
-	*/
-	explicit CPeriodState(
-		const futsim::types::CPlayTime::period_time& aPeriodTime
-	);
-
-	/**
 	 * @copydoc IJsonable::ToJSON
 	*/
 	void JSON( json& aJSON ) const noexcept override;

--- a/include/football/CPeriodState.h
+++ b/include/football/CPeriodState.h
@@ -41,15 +41,18 @@ public:
 	 * @param aAwayTeamStrategy Current match strategy for the away team.
 	 * @param aHomeTeamAttack Whether the home team is attacking.
 	 * @param aGenerator RNG to use.
+	 * @param aPeriodPlayPolicy Period play policy.
 	 * @pre The team strategies must both pass \ref CMatchConfiguration::CheckTeamStrategy and \ref CMatch::CheckTeamStrategy
 	*/
+	template <typename T = SDefaultPeriodPlayPolicy> requires types::CPeriodState::period_play_policy<T>
 	explicit CPeriodState(
 		const CMatch& aMatch,
 		const CMatchConfiguration& aMatchConfiguration,
 		const CTeamStrategy& aHomeTeamStrategy,
 		const CTeamStrategy& aAwayTeamStrategy,
 		bool aHomeTeamAttack,
-		std::uniform_random_bit_generator auto& aGenerator
+		std::uniform_random_bit_generator auto& aGenerator,
+		const T& aPeriodPlayPolicy = T{}
 	);
 
 protected:
@@ -96,18 +99,20 @@ private:
 	plays mPlays;
 };
 
+template <typename T> requires types::CPeriodState::period_play_policy<T>
 CPeriodState::CPeriodState(
 	const CMatch& aMatch,
 	const CMatchConfiguration& aMatchConfiguration,
 	const CTeamStrategy& aHomeTeamStrategy,
 	const CTeamStrategy& aAwayTeamStrategy,
 	bool aHomeTeamAttack,
-	std::uniform_random_bit_generator auto& aGenerator
+	std::uniform_random_bit_generator auto& aGenerator,
+	const T& aPeriodPlayPolicy
 )
 {
 	mPlays.reserve( aMatchConfiguration.GetPlayTime().GetPeriodTime() );
 
-	for( futsim::types::CPlayTime::period_time time = 0; time < aMatchConfiguration.GetPlayTime().GetPeriodTime(); ++time )
+	do
 	{
 		if( aHomeTeamAttack )
 			PushPlayState( CPlayState{ aMatch, aMatchConfiguration, aHomeTeamStrategy, aAwayTeamStrategy,
@@ -116,7 +121,7 @@ CPeriodState::CPeriodState(
 			PushPlayState( CPlayState{ aMatch, aMatchConfiguration, aAwayTeamStrategy, aHomeTeamStrategy,
 				aHomeTeamAttack, aGenerator }, aHomeTeamAttack );
 		aHomeTeamAttack = IsHomeTeamAttackNext();
-	}
+	} while( aPeriodPlayPolicy( mPlays, aMatchConfiguration ) );
 }
 
 } // futsim::football namespace

--- a/include/football/CPeriodState.h
+++ b/include/football/CPeriodState.h
@@ -19,6 +19,21 @@ protected:
 
 public:
 	/**
+	 * @brief Default policy functor for the plays of the period.
+	 * @details All configured minutes are played.
+	*/
+	//! 
+	struct SDefaultPeriodPlayPolicy
+	{
+		/**
+		 * @brief Returns whether another minute must be played.
+		 * @param aPlays Plays of the period.
+		 * @param aMatchConfiguration Match configuration.
+		*/
+		bool operator()( const plays& aPlays, const CMatchConfiguration& aMatchConfiguration ) const;
+	};
+
+	/**
 	 * @brief Constructor from the match definition, configuration and current strategies.
 	 * @param aMatch Match definition.
 	 * @param aMatchConfiguration Match configuration.

--- a/include/football/CPeriodState.h
+++ b/include/football/CPeriodState.h
@@ -55,7 +55,7 @@ public:
 	//! Retrieves the \copybrief mPlays
 	const plays& GetPlays() const noexcept;
 
-private:
+protected:
 	/**
 	 * @brief Adds a play to the plays of the period
 	 * @param aPlayState Play to add.

--- a/include/football/types/CPeriodState.h
+++ b/include/football/types/CPeriodState.h
@@ -5,6 +5,7 @@
 namespace futsim::football
 {
 
+class CMatchConfiguration;
 class CPlayState;
 
 namespace types::CPeriodState
@@ -23,6 +24,13 @@ template <typename T = football::CPlayState> struct play
 
 //! Container for the plays in a period.
 using plays = std::vector<play<>>;
+
+//! Concept for a period play policy
+template<typename T> concept period_play_policy =
+	requires ( T aPolicy, const plays & aPlays, const football::CMatchConfiguration & aMatchConfiguration )
+{
+	{ aPolicy( aPlays, aMatchConfiguration ) } -> std::same_as<bool>;
+};
 
 } // types::CPeriodState namespace
 

--- a/src/football/CExtraTimePeriodState.cpp
+++ b/src/football/CExtraTimePeriodState.cpp
@@ -15,6 +15,11 @@ bool CExtraTimePeriodState::SGoldenGoalPeriodPlayPolicy::operator()( const plays
 		&& ( aPlays.back().state.GetChancesStates().empty() || aPlays.back().state.GetChancesStates().back().GetChanceOutcome() != GOAL );
 }
 
+void CExtraTimePeriodState::JSON( json& aJSON ) const noexcept
+{
+	CPeriodState::JSON( aJSON );
+}
+
 const CMatchConfiguration& CExtraTimePeriodState::CheckMatchConfiguration( const CMatchConfiguration& aMatchConfiguration )
 {
 	if( !aMatchConfiguration.GetExtraTime() )

--- a/src/football/CExtraTimePeriodState.cpp
+++ b/src/football/CExtraTimePeriodState.cpp
@@ -8,6 +8,13 @@ bool CExtraTimePeriodState::SDefaultPeriodPlayPolicy::operator()( const plays& a
 	return aPlays.size() < aMatchConfiguration.GetExtraTime()->GetPeriodTime();
 }
 
+bool CExtraTimePeriodState::SGoldenGoalPeriodPlayPolicy::operator()( const plays& aPlays, const CMatchConfiguration& aMatchConfiguration ) const
+{
+	using enum types::CGoalDrawConfiguration::E_CHANCE_OUTCOME;
+	return SDefaultPeriodPlayPolicy::operator()( aPlays, aMatchConfiguration )
+		&& ( aPlays.back().state.GetChancesStates().empty() || aPlays.back().state.GetChancesStates().back().GetChanceOutcome() != GOAL );
+}
+
 bool CExtraTimePeriodState::HasGoalBeenScoredLast() const
 {
 	using enum types::CGoalDrawConfiguration::E_CHANCE_OUTCOME;

--- a/src/football/CExtraTimePeriodState.cpp
+++ b/src/football/CExtraTimePeriodState.cpp
@@ -1,1 +1,20 @@
 #include "football/CExtraTimePeriodState.h"
+
+namespace futsim::football
+{
+
+bool CExtraTimePeriodState::HasGoalBeenScoredLast() const
+{
+	using enum types::CGoalDrawConfiguration::E_CHANCE_OUTCOME;
+	const auto& lastPlay = GetPlays().back();
+	return !lastPlay.state.GetChancesStates().empty() && lastPlay.state.GetChancesStates().back().GetChanceOutcome() == GOAL;
+}
+
+const CMatchConfiguration& CExtraTimePeriodState::CheckMatchConfiguration( const CMatchConfiguration& aMatchConfiguration )
+{
+	if( !aMatchConfiguration.GetExtraTime() )
+		throw std::invalid_argument{ "The match configuration cannot configure an extra time period state." };
+	return aMatchConfiguration;
+}
+
+} // futsim::football namespace

--- a/src/football/CExtraTimePeriodState.cpp
+++ b/src/football/CExtraTimePeriodState.cpp
@@ -3,6 +3,11 @@
 namespace futsim::football
 {
 
+bool CExtraTimePeriodState::SDefaultPeriodPlayPolicy::operator()( const plays& aPlays, const CMatchConfiguration& aMatchConfiguration ) const
+{
+	return aPlays.size() < aMatchConfiguration.GetExtraTime()->GetPeriodTime();
+}
+
 bool CExtraTimePeriodState::HasGoalBeenScoredLast() const
 {
 	using enum types::CGoalDrawConfiguration::E_CHANCE_OUTCOME;

--- a/src/football/CExtraTimePeriodState.cpp
+++ b/src/football/CExtraTimePeriodState.cpp
@@ -15,13 +15,6 @@ bool CExtraTimePeriodState::SGoldenGoalPeriodPlayPolicy::operator()( const plays
 		&& ( aPlays.back().state.GetChancesStates().empty() || aPlays.back().state.GetChancesStates().back().GetChanceOutcome() != GOAL );
 }
 
-bool CExtraTimePeriodState::HasGoalBeenScoredLast() const
-{
-	using enum types::CGoalDrawConfiguration::E_CHANCE_OUTCOME;
-	const auto& lastPlay = GetPlays().back();
-	return !lastPlay.state.GetChancesStates().empty() && lastPlay.state.GetChancesStates().back().GetChanceOutcome() == GOAL;
-}
-
 const CMatchConfiguration& CExtraTimePeriodState::CheckMatchConfiguration( const CMatchConfiguration& aMatchConfiguration )
 {
 	if( !aMatchConfiguration.GetExtraTime() )

--- a/src/football/CExtraTimePeriodState.cpp
+++ b/src/football/CExtraTimePeriodState.cpp
@@ -1,0 +1,1 @@
+#include "football/CExtraTimePeriodState.h"

--- a/src/football/CPeriodState.cpp
+++ b/src/football/CPeriodState.cpp
@@ -10,13 +10,6 @@ bool CPeriodState::SDefaultPeriodPlayPolicy::operator()( const plays& aPlays, co
 	return aPlays.size() < aMatchConfiguration.GetPlayTime().GetPeriodTime();
 }
 
-CPeriodState::CPeriodState(
-	const futsim::types::CPlayTime::period_time& aPeriodTime
-)
-{
-	mPlays.reserve( aPeriodTime );
-}
-
 const CPeriodState::plays& CPeriodState::GetPlays() const noexcept
 {
 	return mPlays;

--- a/src/football/CPeriodState.cpp
+++ b/src/football/CPeriodState.cpp
@@ -5,6 +5,11 @@
 namespace futsim::football
 {
 
+bool CPeriodState::SDefaultPeriodPlayPolicy::operator()( const plays& aPlays, const CMatchConfiguration& aMatchConfiguration ) const
+{
+	return aPlays.size() < aMatchConfiguration.GetPlayTime().GetPeriodTime();
+}
+
 CPeriodState::CPeriodState(
 	const futsim::types::CPlayTime::period_time& aPeriodTime
 )

--- a/src/football/CPeriodState.cpp
+++ b/src/football/CPeriodState.cpp
@@ -5,6 +5,13 @@
 namespace futsim::football
 {
 
+CPeriodState::CPeriodState(
+	const futsim::types::CPlayTime::period_time& aPeriodTime
+)
+{
+	mPlays.reserve( aPeriodTime );
+}
+
 const CPeriodState::plays& CPeriodState::GetPlays() const noexcept
 {
 	return mPlays;

--- a/tests/FileList.cmake
+++ b/tests/FileList.cmake
@@ -12,6 +12,7 @@ SET(FUTSIM_TESTS_UNIT_FOOTBALL_SOURCE
 	unit/football/TChancesDrawConfiguration.cpp
 	unit/football/TChanceState.cpp
 	unit/football/TDrawConfiguration.cpp
+	unit/football/TExtraTimePeriodState.cpp
 	unit/football/TFoulDrawConfiguration.cpp
 	unit/football/TFoulState.cpp
 	unit/football/TGoalDrawConfiguration.cpp

--- a/tests/unit/football/TExtraTimePeriodState.cpp
+++ b/tests/unit/football/TExtraTimePeriodState.cpp
@@ -1,0 +1,72 @@
+#include "ITest.h"
+
+#include "football/CExtraTimePeriodState.h"
+
+#include "JsonUtils.h"
+
+#include <iostream>
+
+using namespace futsim::football;
+using namespace nlohmann;
+
+constexpr bool PRINT_OUTPUT = false;
+
+INITIALIZE_TEST( TPeriodState )
+
+void TPeriodState::TestExceptions() const
+{
+}
+
+std::vector<std::string> TPeriodState::ObtainedResults() const noexcept
+{
+	std::vector<std::string> result;
+
+	std::mt19937 rng{ 1234 };
+	const CTeam team{ "Luton Town FC", "lut", "Rob Edwards", {
+			CPlayer{ "Thomas", "Kaminski", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ { 70, 1, 1, 1 }, {} } },
+			CPlayer{ "Dan", "Potts", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ { 1, 70, 1, 1 }, {} } },
+			CPlayer{ "Tom", "Lockyer", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ { 1, 80, 1, 1 }, {} } },
+			CPlayer{ "Issa", "Kaboré", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ { 1, 60, 1, 1 }, {} } },
+			CPlayer{ "Amari'i", "Bell", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ { 1, 60, 1, 1 }, {} } },
+			CPlayer{ "Ross", "Barkley", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ { 1, 1, 80, 1 }, {} } },
+			CPlayer{ "Marvelous", "Nakamba", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ { 1, 1, 75, 1 }, {} } },
+			CPlayer{ "Pelly Ruddock", "Mpanzu", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ { 1, 1, 60, 1 }, {} } },
+			CPlayer{ "Jordan", "Clark", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ { 1, 1, 70, 1 }, {} } },
+			CPlayer{ "Carlton", "Morris", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ { 1, 1, 1, 75 }, {} } },
+			CPlayer{ "Elijah", "Adebayo", {}, 35, futsim::E_NATIONALITY::ARG, CPlayerSkills{ { 1, 1, 1, 75 }, {} } },
+			},
+			1.2, 11000, 2000 };
+	const CTeamStrategy homeTeamStrategy{ "A", CLineup{ "Kaminski",
+			types::CLineup::names{ "Potts", "Lockyer", "Kaboré", "Bell" },
+			{}, types::CLineup::names{ "Barkley", "Nakamba", "Mpanzu", "Clark" }, {},
+			types::CLineup::names{ "Morris", "Adebayo" }, {} } };
+	const CTeamStrategy awayTeamStrategy{ "N", homeTeamStrategy.GetLineup() };
+
+	const CMatchConfiguration matchConfig{ CPlayTime{}, CLineupConfiguration{}, true,
+			CTacticsConfiguration{}, CTieCondition{}, CExtraTime{}, CPenaltyShootoutConfiguration{} };
+	const CMatchConfiguration goldenGoalMatchConfig{ CPlayTime{}, CLineupConfiguration{}, true, CTacticsConfiguration{}, CTieCondition{},
+			CExtraTime{ CExtraTime::DEFAULT_PERIOD_COUNT, 90, CExtraTime::DEFAULT_AVAILABLE_SUBS, E_GOAL_RULE::GOLDEN_GOAL },
+			CPenaltyShootoutConfiguration{} };
+
+	for( const auto& extraTimePeriodState : {
+		CExtraTimePeriodState{ CMatch{ team, team, CStadium{ "The New Lawn", 5147, 1 }, "Michael Oliver" },
+			matchConfig, homeTeamStrategy, awayTeamStrategy, true, rng },
+		CExtraTimePeriodState{ CMatch{ team, team, CStadium{ "The New Lawn", 5147, 1 }, "Michael Oliver" },
+			goldenGoalMatchConfig, homeTeamStrategy, awayTeamStrategy, false, rng },
+		} )
+	{
+		result.push_back( std::string{ CExtraTimePeriodState::JSON_PLAYS } + ": "
+			+ std::to_string( extraTimePeriodState.GetPlays().size() ) );
+
+		futsim::types::IJsonable::json outputJSON;
+		AddToJSONKey( outputJSON, extraTimePeriodState );
+		result.push_back( outputJSON.dump( 1, '\t' ) );
+	}
+
+	return PRINT_OUTPUT ? result : std::vector<std::string>{};
+}
+
+std::vector<std::string> TPeriodState::ExpectedResults() const noexcept
+{
+	return {};
+}

--- a/tests/unit/football/TExtraTimePeriodState.cpp
+++ b/tests/unit/football/TExtraTimePeriodState.cpp
@@ -15,6 +15,9 @@ INITIALIZE_TEST( TPeriodState )
 
 void TPeriodState::TestExceptions() const
 {
+	// Test CheckMatchConfiguration
+	CheckException( []() { CExtraTimePeriodState::CheckMatchConfiguration( CMatchConfiguration{} ); },
+		"The match configuration cannot configure an extra time period state." );
 }
 
 std::vector<std::string> TPeriodState::ObtainedResults() const noexcept


### PR DESCRIPTION
Reuses period state by introducing a policy to determine the end of the period.

- The default for a normal period is taken from the match period configuration.
- The default for an extra time period is taken from the extra time period configuration.
- Golden goal adds the constraint that the period must end after a goal is scored.
- Silver goal does not affect the period.