### PR TITLE
Add configuration constraints

### DIFF
--- a/src/football/CMatchConfiguration.cpp
+++ b/src/football/CMatchConfiguration.cpp
@@ -29,6 +29,15 @@ const types::CMatchConfiguration::optional_extra_time& CheckExtraTime(
 	const types::CMatchConfiguration::optional_extra_time& aExtraTime,
 	const types::CMatchConfiguration::optional_tie_condition& aTieCondition );
 
+/**
+ * @brief Checks that the penalty shootout is only configured with a tie condition.
+ * @param aPenaltyShootoutConfiguration Penalty shootout configuration.
+ * @param aTieCondition Tie condition.
+*/
+const types::CMatchConfiguration::optional_penalty_shootout_configuration& CheckPenaltyShootoutConfiguration(
+	const types::CMatchConfiguration::optional_penalty_shootout_configuration& aPenaltyShootoutConfiguration,
+	const types::CMatchConfiguration::optional_tie_condition& aTieCondition );
+
 } // anonymous namespace
 
 CMatchConfiguration::CMatchConfiguration(
@@ -47,7 +56,7 @@ CMatchConfiguration::CMatchConfiguration(
 	mTacticsConfiguration( aTacticsConfiguration ),
 	mTieCondition( CheckTieCondition( aTieCondition, aPenaltyShootoutConfiguration ) ),
 	mExtraTime( CheckExtraTime( aExtraTime, mTieCondition ) ),
-	mPenaltyShootoutConfiguration( aPenaltyShootoutConfiguration ),
+	mPenaltyShootoutConfiguration( CheckPenaltyShootoutConfiguration( aPenaltyShootoutConfiguration, mTieCondition ) ),
 	mDrawConfiguration( aDrawConfiguration )
 {
 }
@@ -153,6 +162,16 @@ const types::CMatchConfiguration::optional_extra_time& CheckExtraTime(
 	return aExtraTime;
 }
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error checking the extra time configuration." )
+
+const types::CMatchConfiguration::optional_penalty_shootout_configuration& CheckPenaltyShootoutConfiguration(
+	const types::CMatchConfiguration::optional_penalty_shootout_configuration& aPenaltyShootoutConfiguration,
+	const types::CMatchConfiguration::optional_tie_condition& aTieCondition ) try
+{
+	if( aPenaltyShootoutConfiguration && !aTieCondition )
+		throw std::invalid_argument( "There cannot be a penalty shootout without a tie condition." );
+	return aPenaltyShootoutConfiguration;
+}
+FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error checking the penalty shootout configuration." )
 
 } // anonymous namespace
 

--- a/src/football/CMatchConfiguration.cpp
+++ b/src/football/CMatchConfiguration.cpp
@@ -20,6 +20,15 @@ const types::CMatchConfiguration::optional_tie_condition& CheckTieCondition(
 	const types::CMatchConfiguration::optional_tie_condition& aTieCondition,
 	const types::CMatchConfiguration::optional_penalty_shootout_configuration& aPenaltyShootoutConfiguration );
 
+/**
+ * @brief Checks that the extra time is only configured with a tie condition.
+ * @param aExtraTime Extra time configuration.
+ * @param aTieCondition Tie condition.
+*/
+const types::CMatchConfiguration::optional_extra_time& CheckExtraTime(
+	const types::CMatchConfiguration::optional_extra_time& aExtraTime,
+	const types::CMatchConfiguration::optional_tie_condition& aTieCondition );
+
 } // anonymous namespace
 
 CMatchConfiguration::CMatchConfiguration(
@@ -37,7 +46,7 @@ CMatchConfiguration::CMatchConfiguration(
 	mApplyAmbientFactor( aApplyAmbientFactor ),
 	mTacticsConfiguration( aTacticsConfiguration ),
 	mTieCondition( CheckTieCondition( aTieCondition, aPenaltyShootoutConfiguration ) ),
-	mExtraTime( aExtraTime ),
+	mExtraTime( CheckExtraTime( aExtraTime, mTieCondition ) ),
 	mPenaltyShootoutConfiguration( aPenaltyShootoutConfiguration ),
 	mDrawConfiguration( aDrawConfiguration )
 {
@@ -134,6 +143,16 @@ const types::CMatchConfiguration::optional_tie_condition& CheckTieCondition(
 	return aTieCondition;
 }
 FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error checking the tie condition." )
+
+const types::CMatchConfiguration::optional_extra_time& CheckExtraTime(
+	const types::CMatchConfiguration::optional_extra_time& aExtraTime,
+	const types::CMatchConfiguration::optional_tie_condition& aTieCondition ) try
+{
+	if( aExtraTime && !aTieCondition )
+		throw std::invalid_argument( "There cannot be extra time without a tie condition." );
+	return aExtraTime;
+}
+FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error checking the extra time configuration." )
 
 } // anonymous namespace
 

--- a/src/football/CMatchConfiguration.cpp
+++ b/src/football/CMatchConfiguration.cpp
@@ -68,8 +68,9 @@ CMatchConfiguration::CMatchConfiguration( const json& aJSON ) try :
 	mApplyAmbientFactor( ValueFromOptionalJSONKey<bool>( aJSON, JSON_APPLY_AMBIENT_FACTOR, DEFAULT_APPLY_AMBIENT_FACTOR ) ),
 	mTacticsConfiguration( ValueFromOptionalJSONKey<CTacticsConfiguration>( aJSON ) ),
 	mTieCondition( ValueFromOptionalJSONKey<optional_tie_condition>( aJSON, CTieCondition::JSON_KEY, {} ) ),
-	mExtraTime( ValueFromOptionalJSONKey<optional_extra_time>( aJSON, CExtraTime::JSON_KEY, {} ) ),
-	mPenaltyShootoutConfiguration( ValueFromOptionalJSONKey<optional_penalty_shootout_configuration>( aJSON, CPenaltyShootoutConfiguration::JSON_KEY, {} ) ),
+	mExtraTime( CheckExtraTime( ValueFromOptionalJSONKey<optional_extra_time>( aJSON, CExtraTime::JSON_KEY, {} ), mTieCondition ) ),
+	mPenaltyShootoutConfiguration( CheckPenaltyShootoutConfiguration(
+		ValueFromOptionalJSONKey<optional_penalty_shootout_configuration>( aJSON, CPenaltyShootoutConfiguration::JSON_KEY, {} ), mTieCondition ) ),
 	mDrawConfiguration( ValueFromOptionalJSONKey<CDrawConfiguration>( aJSON ) )
 {
 	CheckTieCondition( mTieCondition, mPenaltyShootoutConfiguration );

--- a/src/football/CPeriodStates.cpp
+++ b/src/football/CPeriodStates.cpp
@@ -18,9 +18,7 @@ bool CPeriodStates::SDefaultExtraTimePeriodPolicy::operator()(
 
 const CMatchConfiguration& CPeriodStates::SDefaultExtraTimePeriodPolicy::CheckMatchConfiguration( const CMatchConfiguration& aMatchConfiguration )
 {
-	if( !CPeriodState::SDefaultExtraTimePeriodPlayPolicy::CheckMatchConfiguration( aMatchConfiguration ).GetTieCondition() )
-		throw std::invalid_argument{ "The match configuration cannot configure the extra time period states." };
-	return aMatchConfiguration;
+	return CPeriodState::SDefaultExtraTimePeriodPlayPolicy::CheckMatchConfiguration( aMatchConfiguration );
 }
 
 bool CPeriodStates::SSilverGoalPeriodPolicy::operator()(

--- a/tests/unit/football/TMatchConfiguration.cpp
+++ b/tests/unit/football/TMatchConfiguration.cpp
@@ -31,6 +31,16 @@ void TMatchConfiguration::TestExceptions() const
 				}
 			}
 		} )" ); }, "There cannot be a tie condition without a penalty shootout configuration" );
+	CheckException( []() { futsim::ValueFromJSONKeyString<CMatchConfiguration>( R"( {
+			"Match configuration": {
+				"Extra time": {}
+			}
+		} )" ); }, "There cannot be extra time without a tie condition." );
+	CheckException( []() { futsim::ValueFromJSONKeyString<CMatchConfiguration>( R"( {
+			"Match configuration": {
+				"Penalty shootout configuration": {}
+			}
+		} )" ); }, "There cannot be a penalty shootout without a tie condition." );
 
 	// Test CheckTeamStrategy
 	{

--- a/tests/unit/football/TMatchConfiguration.cpp
+++ b/tests/unit/football/TMatchConfiguration.cpp
@@ -17,6 +17,10 @@ void TMatchConfiguration::TestExceptions() const
 	// Test member constructor
 	CheckException( []() { CMatchConfiguration{ CPlayTime{}, CLineupConfiguration{}, true, CTacticsConfiguration{}, CTieCondition{}, {}, {} }; },
 		"There cannot be a tie condition without a penalty shootout configuration" );
+	CheckException( []() { CMatchConfiguration{ CPlayTime{}, CLineupConfiguration{}, true, CTacticsConfiguration{}, {}, CExtraTime{}, {} }; },
+		"There cannot be extra time without a tie condition." );
+	CheckException( []() { CMatchConfiguration{ CPlayTime{}, CLineupConfiguration{}, true, CTacticsConfiguration{}, {}, {}, CPenaltyShootoutConfiguration{} }; },
+		"There cannot be a penalty shootout without a tie condition." );
 
 	// Test JSON constructor
 	CheckException( []() { futsim::ValueFromJSONKeyString<CMatchConfiguration>( R"( {

--- a/tests/unit/football/TPeriodStates.cpp
+++ b/tests/unit/football/TPeriodStates.cpp
@@ -18,9 +18,6 @@ void TPeriodStates::TestExceptions() const
 	// Test CheckMatchConfiguration
 	CheckException( []() { CPeriodStates::SDefaultExtraTimePeriodPolicy::CheckMatchConfiguration( CMatchConfiguration{} ); },
 		"The match configuration cannot be used for the default extra time period play policy." );
-	CheckException( []() { CPeriodStates::SDefaultExtraTimePeriodPolicy::CheckMatchConfiguration( CMatchConfiguration{
-		CPlayTime{}, CLineupConfiguration{}, true, CTacticsConfiguration{}, {}, CExtraTime{}, CPenaltyShootoutConfiguration{} } ); },
-		"The match configuration cannot configure the extra time period states." );
 }
 
 std::vector<std::string> TPeriodStates::ObtainedResults() const noexcept


### PR DESCRIPTION
Only allow extra time or penalty shootouts when a tie condition is provided