### PR TITLE
Use installed json package

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,8 +30,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: ts-graphviz/setup-graphviz@v2
-    - uses: ssciwr/doxygen-install@v1
+    - name: Install dependencies
+      run: |
+       sudo apt-get install nlohmann-json3-dev graphviz doxygen ninja-build
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/test-multi-platform.yml
+++ b/.github/workflows/test-multi-platform.yml
@@ -19,8 +19,8 @@ jobs:
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         config:
-          - { os: ubuntu-latest, build_type: "Release", c_compiler: "gcc", cpp_compiler: "g++" }
-          - { os: ubuntu-latest, build_type: "Release", c_compiler: "clang-18", cpp_compiler: "clang++-18" }
+          - { os: ubuntu-24.04, build_type: "Release", c_compiler: "gcc", cpp_compiler: "g++" }
+          - { os: ubuntu-24.04, build_type: "Release", c_compiler: "clang-18", cpp_compiler: "clang++-18" }
           - { os: windows-latest, build_type: "Release", c_compiler: "cl", cpp_compiler: "cl" }
 
     steps:
@@ -40,7 +40,7 @@ jobs:
        sudo ./llvm.sh 18
 
     - name: Install nlohmann_json
-      if: matrix.config.os == 'ubuntu-latest'
+      if: matrix.config.os == 'ubuntu-24.04'
       run: |
        sudo apt-get install nlohmann-json3-dev
 

--- a/.github/workflows/test-multi-platform.yml
+++ b/.github/workflows/test-multi-platform.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install nlohmann_json in Windows
       if: matrix.config.os == 'windows-latest'
       run: |
-       git clone https://github.com/nlohmann/json externals
+       vcpkg install nlohmann-json
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
@@ -61,6 +61,7 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
         -DCMAKE_CXX_COMPILER=${{ matrix.config.cpp_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
         -S ${{ github.workspace }}

--- a/.github/workflows/test-multi-platform.yml
+++ b/.github/workflows/test-multi-platform.yml
@@ -39,10 +39,15 @@ jobs:
        chmod +x ./llvm.sh
        sudo ./llvm.sh 18
 
-    - name: Install nlohmann_json
+    - name: Install nlohmann_json in Ubuntu
       if: matrix.config.os == 'ubuntu-24.04'
       run: |
        sudo apt-get install nlohmann-json3-dev
+
+    - name: Install nlohmann_json in Windows
+      if: matrix.config.os == 'windows-latest'
+      run: |
+       git clone https://github.com/nlohmann/json externals
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/test-multi-platform.yml
+++ b/.github/workflows/test-multi-platform.yml
@@ -21,7 +21,8 @@ jobs:
         config:
           - { os: ubuntu-24.04, build_type: "Release", c_compiler: "gcc", cpp_compiler: "g++", generator: "Ninja" }
           - { os: ubuntu-24.04, build_type: "Release", c_compiler: "clang-18", cpp_compiler: "clang++-18", generator: "Ninja" }
-          - { os: windows-latest, build_type: "Release", c_compiler: "cl", cpp_compiler: "cl", generator: "\"Visual Studio 17 2022\"" }
+          - { os: windows-latest, build_type: "Release", c_compiler: "cl", cpp_compiler: "cl", generator: "\"Visual Studio 17 2022\"",
+              extra_flags: "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" }
 
     steps:
     - uses: actions/checkout@v4
@@ -51,15 +52,15 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
         -DCMAKE_CXX_COMPILER=${{ matrix.config.cpp_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
         -S ${{ github.workspace }}
         -G ${{ matrix.config.generator }}
+        ${{ matrix.config.extra_flags }}
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.config.build_type }}
+      run: cmake -j6 --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.config.build_type }}
     - name: Test
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail

--- a/.github/workflows/test-multi-platform.yml
+++ b/.github/workflows/test-multi-platform.yml
@@ -19,9 +19,9 @@ jobs:
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         config:
-          - { os: ubuntu-24.04, build_type: "Release", c_compiler: "gcc", cpp_compiler: "g++", generator: "Ninja" }
-          - { os: ubuntu-24.04, build_type: "Release", c_compiler: "clang-18", cpp_compiler: "clang++-18", generator: "Ninja" }
-          - { os: windows-latest, build_type: "Release", c_compiler: "cl", cpp_compiler: "cl", generator: "\"Visual Studio 17 2022\"",
+          - { os: ubuntu-24.04, build_type: "Release", c_compiler: "gcc", cpp_compiler: "g++" }
+          - { os: ubuntu-24.04, build_type: "Release", c_compiler: "clang-18", cpp_compiler: "clang++-18" }
+          - { os: windows-latest, build_type: "Release", c_compiler: "cl", cpp_compiler: "cl",
               extra_flags: "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" }
 
     steps:
@@ -37,8 +37,10 @@ jobs:
     - name: Install Windows dependencies
       if: matrix.config.os == 'windows-latest'
       run: |
-       choco install graphviz doxygen.install
+       choco install graphviz doxygen.install ninja
        vcpkg install nlohmann-json
+
+    - uses: ilammy/msvc-dev-cmd@v1.13.0
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
@@ -55,12 +57,12 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.config.cpp_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
         -S ${{ github.workspace }}
-        -G ${{ matrix.config.generator }}
+        -G Ninja
         ${{ matrix.config.extra_flags }}
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      run: cmake -j6 --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.config.build_type }}
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.config.build_type }}
     - name: Test
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail

--- a/.github/workflows/test-multi-platform.yml
+++ b/.github/workflows/test-multi-platform.yml
@@ -19,18 +19,25 @@ jobs:
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         config:
-          - { os: ubuntu-24.04, build_type: "Release", c_compiler: "gcc", cpp_compiler: "g++" }
-          - { os: ubuntu-24.04, build_type: "Release", c_compiler: "clang-18", cpp_compiler: "clang++-18" }
-          - { os: windows-latest, build_type: "Release", c_compiler: "cl", cpp_compiler: "cl" }
+          - { os: ubuntu-24.04, build_type: "Release", c_compiler: "gcc", cpp_compiler: "g++", generator: "Ninja" }
+          - { os: ubuntu-24.04, build_type: "Release", c_compiler: "clang-18", cpp_compiler: "clang++-18", generator: "Ninja" }
+          - { os: windows-latest, build_type: "Release", c_compiler: "cl", cpp_compiler: "cl", generator: "\"Visual Studio 17 2022\"" }
 
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: ts-graphviz/setup-graphviz@v2
-    - uses: ssciwr/doxygen-install@v1
-    - uses: ilammy/msvc-dev-cmd@v1
-    - uses: seanmiddleditch/gha-setup-ninja@v4
+
+    - name: Install Ubuntu dependencies
+      if: matrix.config.os == 'ubuntu-24.04'
+      run: |
+       sudo apt-get install nlohmann-json3-dev graphviz doxygen ninja-build
+
+    - name: Install Windows dependencies
+      if: matrix.config.os == 'windows-latest'
+      run: |
+       choco install graphviz doxygen.install
+       vcpkg install nlohmann-json
 
     - name: Install Clang 18
       if: matrix.config.cpp_compiler == 'clang++-18'
@@ -38,16 +45,6 @@ jobs:
        wget -O llvm.sh https://apt.llvm.org/llvm.sh
        chmod +x ./llvm.sh
        sudo ./llvm.sh 18
-
-    - name: Install nlohmann_json in Ubuntu
-      if: matrix.config.os == 'ubuntu-24.04'
-      run: |
-       sudo apt-get install nlohmann-json3-dev
-
-    - name: Install nlohmann_json in Windows
-      if: matrix.config.os == 'windows-latest'
-      run: |
-       vcpkg install nlohmann-json
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
@@ -65,7 +62,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.config.cpp_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
         -S ${{ github.workspace }}
-        -G Ninja
+        -G ${{ matrix.config.generator }}
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).

--- a/.github/workflows/test-multi-platform.yml
+++ b/.github/workflows/test-multi-platform.yml
@@ -39,13 +39,6 @@ jobs:
        choco install graphviz doxygen.install
        vcpkg install nlohmann-json
 
-    - name: Install Clang 18
-      if: matrix.config.cpp_compiler == 'clang++-18'
-      run: |
-       wget -O llvm.sh https://apt.llvm.org/llvm.sh
-       chmod +x ./llvm.sh
-       sudo ./llvm.sh 18
-
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
       id: strings

--- a/.github/workflows/test-multi-platform.yml
+++ b/.github/workflows/test-multi-platform.yml
@@ -39,6 +39,11 @@ jobs:
        chmod +x ./llvm.sh
        sudo ./llvm.sh 18
 
+    - name: Install nlohmann_json
+      if: matrix.config.os == 'ubuntu-latest'
+      run: |
+       sudo apt-get install nlohmann-json3-dev
+
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
       id: strings

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "doc/content/MathJax"]
 	path = doc/content/MathJax
 	url = https://github.com/mathjax/MathJax.git
-[submodule "externals/json"]
-	path = externals/json
-	url = git@github.com:nlohmann/json.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJSON_USE_IMPLICIT_CONVERSIONS=0")
 set(CMAKE_CXX_FLAGS_RELEASE "-Os")
 
 # Find json package
-find_package(nlohmann_json)
+find_package(nlohmann_json 3.11 REQUIRED)
 
 # Function to add a new object module
 function(add_futsim_object_module MODULE_NAME SOURCES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,8 @@ configure_file(${FUTSIM_INCLUDE_DIR}/Config.h.in ${FUTSIM_INCLUDE_DIR}/Config.h)
 configure_file(${FUTSIM_INCLUDE_DIR}/ENationality.h.in ${FUTSIM_INCLUDE_DIR}/ENationality.h)
 
 # Include directories
-include_directories(${FUTSIM_INCLUDE_DIR} ${FUTSIM_DIR}/src)
+find_path(JSON_INCLUDE_DIR NAMES nlohmann)
+include_directories(${FUTSIM_INCLUDE_DIR} ${FUTSIM_DIR}/src ${JSON_INCLUDE_DIR})
 
 # Link directories
 link_directories(${FUTSIM_LIBS_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJSON_USE_IMPLICIT_CONVERSIONS=0")
 set(CMAKE_CXX_FLAGS_RELEASE "-Os")
 
 # Find json package
-set(JSON_DIR ${FUTSIM_DIR}/externals/json)
-add_subdirectory(${JSON_DIR})
+find_package(nlohmann_json)
 
 # Function to add a new object module
 function(add_futsim_object_module MODULE_NAME SOURCES)
@@ -101,7 +100,7 @@ configure_file(${FUTSIM_INCLUDE_DIR}/Config.h.in ${FUTSIM_INCLUDE_DIR}/Config.h)
 configure_file(${FUTSIM_INCLUDE_DIR}/ENationality.h.in ${FUTSIM_INCLUDE_DIR}/ENationality.h)
 
 # Include directories
-include_directories(${FUTSIM_INCLUDE_DIR} ${FUTSIM_DIR}/src ${JSON_DIR}/include)
+include_directories(${FUTSIM_INCLUDE_DIR} ${FUTSIM_DIR}/src)
 
 # Link directories
 link_directories(${FUTSIM_LIBS_DIR})


### PR DESCRIPTION
Rely on nlohmann_json installed package instead of adding it as a submodule.

This will considerably reduce the size of cloning and will no longer have to manually update the nlohmann_json submodule