### PR TITLE
Use mathjax cdn

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "doc/content/MathJax"]
-	path = doc/content/MathJax
-	url = https://github.com/mathjax/MathJax.git

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
 set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 set(CONTENT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/content)
-set(MATHJAX_PATH ${CONTENT_PATH}/MathJax)
 
 # Configure doxyfile
 configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
@@ -21,7 +20,6 @@ list(TRANSFORM FUTSIM_EXTERNAL_HEADERS PREPEND ${FUTSIM_DIR}/ OUTPUT_VARIABLE FU
 
 # Add command that generates the doxygen documentation
 add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/html/index.html
-	COMMAND ${CMAKE_COMMAND} -E copy_directory ${MATHJAX_PATH}/es5 ${CMAKE_CURRENT_SOURCE_DIR}/html/MathJax/es5
 	COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 	COMMENT "Generating documentation with Doxygen"

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1809,7 +1809,7 @@ MATHJAX_FORMAT         = chtml
 # - in case of MathJax version 3: https://cdn.jsdelivr.net/npm/mathjax@3
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = ./MathJax
+MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@3
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example


### PR DESCRIPTION
This allows to have no submodules.

Smaller repo size when cloning.
Automatically use latest MathJax 3 version.