### PR TITLE
Output test in files

### DIFF
--- a/tests/ATest.cpp
+++ b/tests/ATest.cpp
@@ -71,6 +71,7 @@ void ATest::CheckResults( const std::vector<std::string>& aObtained, const std::
 		ss << "The obtained results do not match the expected results.\n"
 			<< "Expected\n"
 			<< "-----------------------------------------\n";
+		mExpectedStream << "In test " << mName << ":\n";
 		std::ranges::for_each( aExpected, [ &ss, this ]( const auto& aResult )
 		{
 			ss << aResult << "\n";
@@ -78,6 +79,7 @@ void ATest::CheckResults( const std::vector<std::string>& aObtained, const std::
 		} );
 		ss << "Obtained\n"
 			<< "-----------------------------------------\n";
+		mObtainedStream << "In test " << mName << ":\n";
 		std::ranges::for_each( aObtained, [ &ss, this ]( const auto& aResult )
 		{
 			ss << aResult << "\n";

--- a/tests/ATest.cpp
+++ b/tests/ATest.cpp
@@ -14,7 +14,8 @@ constexpr std::string_view REL_PATH = "../Testing/Temporary";
 
 } // anonymous namespace
 
-ATest::ATest()
+ATest::ATest( const std::string_view aName ) :
+	mName( aName )
 {
 	mExpectedStream.open( std::filesystem::current_path() / REL_PATH / EXPECTED_FILENAME, std::ios_base::app );
 	mObtainedStream.open( std::filesystem::current_path() / REL_PATH / OBTAINED_FILENAME, std::ios_base::app );

--- a/tests/ATest.cpp
+++ b/tests/ATest.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include <algorithm>
 #include <filesystem>
@@ -14,26 +14,26 @@ constexpr std::string_view REL_PATH = "../Testing/Temporary";
 
 } // anonymous namespace
 
-ITest::ITest()
+ATest::ATest()
 {
 	mExpectedStream.open( std::filesystem::current_path() / REL_PATH / EXPECTED_FILENAME, std::ios_base::app );
 	mObtainedStream.open( std::filesystem::current_path() / REL_PATH / OBTAINED_FILENAME, std::ios_base::app );
 }
 
-ITest::~ITest()
+ATest::~ATest()
 {
 	mExpectedStream.close();
 	mObtainedStream.close();
 }
 
-void ITest::Run() const
+void ATest::Run() const
 {
 	this->TestExceptions();
 
 	CheckResults( this->ObtainedResults(), this->ExpectedResults() );
 }
 
-void ITest::CheckException( const std::function<void()>& aFunction, const std::string_view aExpectedErrorMsg )
+void ATest::CheckException( const std::function<void()>& aFunction, const std::string_view aExpectedErrorMsg )
 {
 	try
 	{
@@ -62,7 +62,7 @@ void ITest::CheckException( const std::function<void()>& aFunction, const std::s
 	throw std::invalid_argument{ ss.str() };
 }
 
-void ITest::CheckResults( const std::vector<std::string>& aObtained, const std::vector<std::string>& aExpected ) const
+void ATest::CheckResults( const std::vector<std::string>& aObtained, const std::vector<std::string>& aExpected ) const
 {
 	if( aObtained != aExpected )
 	{

--- a/tests/ATest.h
+++ b/tests/ATest.h
@@ -67,7 +67,7 @@ private:
 	class CLASS : public ATest													\
 	{																			\
 	public:																		\
-		CLASS( const std::string_view aName ) :									\
+		explicit CLASS( const std::string_view aName ) :									\
 			ATest( aName )														\
 		{																		\
 		}																		\

--- a/tests/ATest.h
+++ b/tests/ATest.h
@@ -14,7 +14,7 @@ public:
 	 * @brief Default constructor.
 	 * @param aName Name of the test.
 	 */
-	ATest( const std::string_view aName );
+	explicit ATest( const std::string_view aName );
 
 	/**
 	 * @brief Virtual destructor to avoid instantiation of interface class.

--- a/tests/ATest.h
+++ b/tests/ATest.h
@@ -12,8 +12,9 @@ class ATest
 public:
 	/**
 	 * @brief Default constructor.
+	 * @param aName Name of the test.
 	 */
-	ATest();
+	ATest( const std::string_view aName );
 
 	/**
 	 * @brief Virtual destructor to avoid instantiation of interface class.
@@ -65,6 +66,12 @@ private:
 #define INITIALIZE_CLASS( CLASS )												\
 	class CLASS : public ATest													\
 	{																			\
+	public:																		\
+		CLASS( const std::string_view aName ) :									\
+			ATest( aName )														\
+		{																		\
+		}																		\
+	private:																	\
 		void TestExceptions() const override; 									\
 		std::vector<std::string> ObtainedResults() const noexcept override; 	\
 		std::vector<std::string> ExpectedResults() const noexcept override; 	\
@@ -76,7 +83,7 @@ private:
 #define INITIALIZE_MAIN( CLASS )				\
 	int main() try								\
 	{											\
-		CLASS{}.Run();							\
+		CLASS{ #CLASS }.Run();					\
 		return 0;								\
 	}											\
 	catch(const std::exception& aException)		\

--- a/tests/ATest.h
+++ b/tests/ATest.h
@@ -55,6 +55,8 @@ private:
 	mutable std::ofstream mExpectedStream;
 	//! Stream for the obtained results.
 	mutable std::ofstream mObtainedStream;
+	//! Name for the test.
+	const std::string_view mName;
 };
 
 /**

--- a/tests/ATest.h
+++ b/tests/ATest.h
@@ -5,20 +5,20 @@
 #include <string_view>
 
 /**
- * @brief Interface class for all tests.
+ * @brief Abstract class for all tests.
 */
-class ITest
+class ATest
 {
 public:
 	/**
 	 * @brief Default constructor.
 	 */
-	ITest();
+	ATest();
 
 	/**
 	 * @brief Virtual destructor to avoid instantiation of interface class.
 	*/
-	virtual ~ITest();
+	virtual ~ATest();
 
 	/**
 	 * @brief Public interface to run the test.
@@ -58,10 +58,10 @@ private:
 };
 
 /**
- * @brief Macro to initialize derived test class from ITest.
+ * @brief Macro to initialize derived test class from ATest.
 */
 #define INITIALIZE_CLASS( CLASS )												\
-	class CLASS : public ITest													\
+	class CLASS : public ATest													\
 	{																			\
 		void TestExceptions() const override; 									\
 		std::vector<std::string> ObtainedResults() const noexcept override; 	\

--- a/tests/FileList.cmake
+++ b/tests/FileList.cmake
@@ -1,5 +1,5 @@
 SET(FUTSIM_TESTS_ENGINE_SOURCE
-	ITest.cpp)
+	ATest.cpp)
 
 SET(FUTSIM_TESTS_UNIT_CORE_SOURCE
 	unit/TEnumDistribution.cpp

--- a/tests/ITest.cpp
+++ b/tests/ITest.cpp
@@ -62,7 +62,7 @@ void ITest::CheckException( const std::function<void()>& aFunction, const std::s
 	throw std::invalid_argument{ ss.str() };
 }
 
-void ITest::CheckResults( const std::vector<std::string>& aObtained, const std::vector<std::string>& aExpected )
+void ITest::CheckResults( const std::vector<std::string>& aObtained, const std::vector<std::string>& aExpected ) const
 {
 	if( aObtained != aExpected )
 	{

--- a/tests/ITest.cpp
+++ b/tests/ITest.cpp
@@ -9,6 +9,7 @@ namespace
 
 constexpr std::string_view EXPECTED_FILENAME = "expected.txt";
 constexpr std::string_view OBTAINED_FILENAME = "obtained.txt";
+constexpr std::string_view REL_PATH = "../Testing/Temporary";
 
 } // anonymous namespace
 

--- a/tests/ITest.cpp
+++ b/tests/ITest.cpp
@@ -4,6 +4,14 @@
 #include <iostream>
 #include <sstream>
 
+namespace
+{
+
+constexpr std::string_view EXPECTED_FILENAME = "expected.txt";
+constexpr std::string_view OBTAINED_FILENAME = "obtained.txt";
+
+} // anonymous namespace
+
 ITest::ITest()
 {
 }

--- a/tests/ITest.cpp
+++ b/tests/ITest.cpp
@@ -70,15 +70,17 @@ void ITest::CheckResults( const std::vector<std::string>& aObtained, const std::
 		ss << "The obtained results do not match the expected results.\n"
 			<< "Expected\n"
 			<< "-----------------------------------------\n";
-		std::ranges::for_each( aExpected, [ &ss ]( const auto& aResult )
+		std::ranges::for_each( aExpected, [ &ss, this ]( const auto& aResult )
 		{
 			ss << aResult << "\n";
+			mExpectedStream << aResult << "\n";
 		} );
 		ss << "Obtained\n"
 			<< "-----------------------------------------\n";
-		std::ranges::for_each( aObtained, [ &ss ]( const auto& aResult )
+		std::ranges::for_each( aObtained, [ &ss, this ]( const auto& aResult )
 		{
 			ss << aResult << "\n";
+			mObtainedStream << aResult << "\n";
 		} );
 		throw std::invalid_argument{ ss.str() };
 	}

--- a/tests/ITest.cpp
+++ b/tests/ITest.cpp
@@ -20,6 +20,12 @@ ITest::ITest()
 	mObtainedStream.open( std::filesystem::current_path() / REL_PATH / OBTAINED_FILENAME, std::ios_base::app );
 }
 
+ITest::~ITest()
+{
+	mExpectedStream.close();
+	mObtainedStream.close();
+}
+
 void ITest::Run() const
 {
 	this->TestExceptions();

--- a/tests/ITest.cpp
+++ b/tests/ITest.cpp
@@ -4,6 +4,10 @@
 #include <iostream>
 #include <sstream>
 
+ITest::ITest()
+{
+}
+
 void ITest::Run() const
 {
 	this->TestExceptions();
@@ -48,10 +52,16 @@ void ITest::CheckResults( const std::vector<std::string>& aObtained, const std::
 		ss << "The obtained results do not match the expected results.\n"
 			<< "Expected\n"
 			<< "-----------------------------------------\n";
-		std::ranges::for_each( aExpected, [ &ss ]( const auto& aResult ) { ss << aResult << "\n"; } );
+		std::ranges::for_each( aExpected, [ &ss ]( const auto& aResult )
+		{
+			ss << aResult << "\n";
+		} );
 		ss << "Obtained\n"
 			<< "-----------------------------------------\n";
-		std::ranges::for_each( aObtained, [ &ss ]( const auto& aResult ) { ss << aResult << "\n"; } );
+		std::ranges::for_each( aObtained, [ &ss ]( const auto& aResult )
+		{
+			ss << aResult << "\n";
+		} );
 		throw std::invalid_argument{ ss.str() };
 	}
 }

--- a/tests/ITest.cpp
+++ b/tests/ITest.cpp
@@ -1,6 +1,7 @@
 #include "ITest.h"
 
 #include <algorithm>
+#include <filesystem>
 #include <iostream>
 #include <sstream>
 
@@ -15,6 +16,8 @@ constexpr std::string_view REL_PATH = "../Testing/Temporary";
 
 ITest::ITest()
 {
+	mExpectedStream.open( std::filesystem::current_path() / REL_PATH / EXPECTED_FILENAME, std::ios_base::app );
+	mObtainedStream.open( std::filesystem::current_path() / REL_PATH / OBTAINED_FILENAME, std::ios_base::app );
 }
 
 void ITest::Run() const

--- a/tests/ITest.h
+++ b/tests/ITest.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <fstream>
 #include <functional>
 #include <string_view>
 
@@ -49,6 +50,11 @@ private:
 	 * @brief Private implementation to get the expected results from the test.
 	*/
 	virtual constexpr std::vector<std::string> ExpectedResults() const noexcept = 0;
+
+	//! Stream for the expected results.
+	mutable std::ofstream mExpectedStream;
+	//! Stream for the obtained results.
+	mutable std::ofstream mObtainedStream;
 };
 
 /**

--- a/tests/ITest.h
+++ b/tests/ITest.h
@@ -34,7 +34,7 @@ private:
 	/**
 	 * @brief Results checker.
 	*/
-	static void CheckResults( const std::vector<std::string>& aObtained, const std::vector<std::string>& aExpected );
+	void CheckResults( const std::vector<std::string>& aObtained, const std::vector<std::string>& aExpected ) const;
 
 	/**
 	 * @brief Private implementation to test exceptions.

--- a/tests/ITest.h
+++ b/tests/ITest.h
@@ -18,7 +18,7 @@ public:
 	/**
 	 * @brief Virtual destructor to avoid instantiation of interface class.
 	*/
-	virtual ~ITest() = default;
+	virtual ~ITest();
 
 	/**
 	 * @brief Public interface to run the test.

--- a/tests/ITest.h
+++ b/tests/ITest.h
@@ -10,6 +10,11 @@ class ITest
 {
 public:
 	/**
+	 * @brief Default constructor.
+	 */
+	ITest();
+
+	/**
 	 * @brief Virtual destructor to avoid instantiation of interface class.
 	*/
 	virtual ~ITest() = default;

--- a/tests/unit/TEnumDistribution.cpp
+++ b/tests/unit/TEnumDistribution.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "CEnumDistribution.h"
 

--- a/tests/unit/TPerson.cpp
+++ b/tests/unit/TPerson.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "CPerson.h"
 

--- a/tests/unit/TPlayTime.cpp
+++ b/tests/unit/TPlayTime.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "CPlayTime.h"
 

--- a/tests/unit/football/TChanceState.cpp
+++ b/tests/unit/football/TChanceState.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CChanceState.h"
 

--- a/tests/unit/football/TChancesDrawConfiguration.cpp
+++ b/tests/unit/football/TChancesDrawConfiguration.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CChancesDrawConfiguration.h"
 

--- a/tests/unit/football/TDrawConfiguration.cpp
+++ b/tests/unit/football/TDrawConfiguration.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CDrawConfiguration.h"
 

--- a/tests/unit/football/TExtraTime.cpp
+++ b/tests/unit/football/TExtraTime.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CExtraTime.h"
 

--- a/tests/unit/football/TFoulDrawConfiguration.cpp
+++ b/tests/unit/football/TFoulDrawConfiguration.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CFoulDrawConfiguration.h"
 

--- a/tests/unit/football/TFoulState.cpp
+++ b/tests/unit/football/TFoulState.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CFoulState.h"
 

--- a/tests/unit/football/TGoalDrawConfiguration.cpp
+++ b/tests/unit/football/TGoalDrawConfiguration.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CGoalDrawConfiguration.h"
 

--- a/tests/unit/football/TLineup.cpp
+++ b/tests/unit/football/TLineup.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CLineup.h"
 

--- a/tests/unit/football/TLineupConfiguration.cpp
+++ b/tests/unit/football/TLineupConfiguration.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CLineupConfiguration.h"
 

--- a/tests/unit/football/TMatch.cpp
+++ b/tests/unit/football/TMatch.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CMatch.h"
 #include "football/CTeamStrategy.h"

--- a/tests/unit/football/TMatchConfiguration.cpp
+++ b/tests/unit/football/TMatchConfiguration.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CMatchConfiguration.h"
 #include "football/CTeamStrategy.h"

--- a/tests/unit/football/TMatchState.cpp
+++ b/tests/unit/football/TMatchState.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CMatchState.h"
 

--- a/tests/unit/football/TPenaltyShootoutConfiguration.cpp
+++ b/tests/unit/football/TPenaltyShootoutConfiguration.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CPenaltyShootoutConfiguration.h"
 

--- a/tests/unit/football/TPenaltyShootoutState.cpp
+++ b/tests/unit/football/TPenaltyShootoutState.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CPenaltyShootoutState.h"
 

--- a/tests/unit/football/TPenaltyState.cpp
+++ b/tests/unit/football/TPenaltyState.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CPenaltyState.h"
 

--- a/tests/unit/football/TPeriodState.cpp
+++ b/tests/unit/football/TPeriodState.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CPeriodState.h"
 #include "football/CExtraTimePeriodPlayPolicy.h"

--- a/tests/unit/football/TPeriodStates.cpp
+++ b/tests/unit/football/TPeriodStates.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CPeriodStates.h"
 #include "football/CExtraTimePeriodPlayPolicy.h"

--- a/tests/unit/football/TPlayState.cpp
+++ b/tests/unit/football/TPlayState.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CPlayState.h"
 

--- a/tests/unit/football/TPlayTime.cpp
+++ b/tests/unit/football/TPlayTime.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CPlayTime.h"
 

--- a/tests/unit/football/TPlayer.cpp
+++ b/tests/unit/football/TPlayer.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CPlayer.h"
 

--- a/tests/unit/football/TPlayerSkills.cpp
+++ b/tests/unit/football/TPlayerSkills.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CPlayerSkills.h"
 

--- a/tests/unit/football/TPossessionDrawConfiguration.cpp
+++ b/tests/unit/football/TPossessionDrawConfiguration.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CPossessionDrawConfiguration.h"
 

--- a/tests/unit/football/TPossessionState.cpp
+++ b/tests/unit/football/TPossessionState.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CPossessionState.h"
 

--- a/tests/unit/football/TStadium.cpp
+++ b/tests/unit/football/TStadium.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CStadium.h"
 

--- a/tests/unit/football/TTacticConfiguration.cpp
+++ b/tests/unit/football/TTacticConfiguration.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CTacticConfiguration.h"
 

--- a/tests/unit/football/TTacticsConfiguration.cpp
+++ b/tests/unit/football/TTacticsConfiguration.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CTacticsConfiguration.h"
 

--- a/tests/unit/football/TTeam.cpp
+++ b/tests/unit/football/TTeam.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CTeam.h"
 

--- a/tests/unit/football/TTeamStrategy.cpp
+++ b/tests/unit/football/TTeamStrategy.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CTeamStrategy.h"
 

--- a/tests/unit/football/TTieCondition.cpp
+++ b/tests/unit/football/TTieCondition.cpp
@@ -1,4 +1,4 @@
-#include "ITest.h"
+#include "ATest.h"
 
 #include "football/CTieCondition.h"
 


### PR DESCRIPTION
When the obtained results do not match the expected ones, the outputs are written in different files `obtained.txt` and `expected.txt` respectively.

These files are created in the `build/Testing/Temporary` folder, where other test logs are created.

Resolves #198.