### PR TITLE
Create add to optional json

### DIFF
--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -160,6 +160,17 @@ inline void AddToJSONKey( is_json_type auto& aJSON, const T& aObject, const std:
 inline void AddToJSONKey( is_json_type auto& aJSON, const is_not_jsonable auto& aObject, const std::string_view aKeyName ) noexcept;
 
 /**
+ * @brief Helper function to add an optional key to a JSON object.
+ * @param aJSON JSON object.
+ * @param aObject Value to add.
+ * @param aKeyName Name of the key under which to add it.
+ * @param aIgnoreValue Value for which the key is not created.
+ * @param aArgs Arguments to be forwarded to the ToJSON method.
+*/
+template<typename T>
+inline void AddToOptionalJSONKey( is_json_type auto& aJSON, const T& aObject, const std::string_view aKeyName = json_traits<T>::KEY, const T& aIgnoreValue = T{}, auto&&... aArgs ) noexcept;
+
+/**
  * @brief Helper function to add a container with keys to a JSON object.
  * @param aJSON JSON object.
  * @param aContainer Container to add.
@@ -282,6 +293,13 @@ inline void AddToJSONKey( is_json_type auto& aJSON, const T& aObject, const std:
 inline void AddToJSONKey( is_json_type auto& aJSON, const is_not_jsonable auto& aObject, const std::string_view aKeyName ) noexcept
 {
 	AddToJSON( aJSON[ aKeyName ], aObject );
+}
+
+template<typename T>
+inline void AddToOptionalJSONKey( is_json_type auto& aJSON, const T& aObject, const std::string_view aKeyName, const T& aIgnoreValue, auto&&... aArgs ) noexcept
+{
+	if( aObject != aIgnoreValue )
+		AddToJSONKey( aJSON, aObject, aKeyName, std::forward<decltype( aArgs )>( aArgs )... );
 }
 
 inline void AddArrayToJSONKey( is_json_type auto& aJSON, const auto& aContainer, const std::string_view aKeyName, auto&&... aArgs ) noexcept

--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -148,16 +148,8 @@ inline void AddKeyArrayToJSON( is_json_type auto& aJSON, const auto& aContainer,
  * @param aArgs Arguments to be forwarded to the ToJSON method.
  * @todo Remove template in favour of auto once MSVC allows to use decltype on local arguments (compiler bug).
 */
-template<is_jsonable T>
+template<typename T>
 inline void AddToJSONKey( is_json_type auto& aJSON, const T& aObject, const std::string_view aKeyName = json_traits<T>::KEY, auto&&... aArgs ) noexcept;
-
-/**
- * @brief Helper function to add a non-jsonable type to a JSON object.
- * @param aJSON JSON object.
- * @param aObject Value to add.
- * @param aKeyName Name of the key under which to add it.
-*/
-inline void AddToJSONKey( is_json_type auto& aJSON, const is_not_jsonable auto& aObject, const std::string_view aKeyName ) noexcept;
 
 /**
  * @brief Helper function to add an optional key to a JSON object.
@@ -284,15 +276,10 @@ inline void AddKeyArrayToJSON( is_json_type auto& aJSON, const auto& aContainer,
 	AddToJSON( aJSON, arrayJSON );
 }
 
-template<is_jsonable T>
+template<typename T>
 inline void AddToJSONKey( is_json_type auto& aJSON, const T& aObject, const std::string_view aKeyName, auto&&... aArgs ) noexcept
 {
 	AddToJSON( aJSON[ aKeyName ], aObject, std::forward<decltype( aArgs )>( aArgs )... );
-}
-
-inline void AddToJSONKey( is_json_type auto& aJSON, const is_not_jsonable auto& aObject, const std::string_view aKeyName ) noexcept
-{
-	AddToJSON( aJSON[ aKeyName ], aObject );
 }
 
 template<typename T>

--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -85,21 +85,13 @@ template<is_not_json_constructible T>
 inline T ValueFromJSONString( const std::string_view& aJSONString );
 
 /**
- * @brief Helper function to construct a jsonable class from a key in a JSON string.
+ * @brief Helper function to construct a class from a key in a JSON string.
  * @param aJSONString JSON string.
  * @param aArgs Extra arguments to be forwarded to the JSON constructor.
  * @param aKeyName Name of the key to search.
 */
-template<is_json_constructible T>
+template<typename T>
 inline T ValueFromJSONKeyString( const std::string_view& aJSONString, const std::string_view aKeyName = json_traits<T>::KEY, auto&&... aArgs );
-
-/**
- * @brief Helper function to construct a non-jsonable type from a key in a JSON string.
- * @param aJSONString JSON string.
- * @param aKeyName Name of the key to search.
-*/
-template<is_not_json_constructible T>
-inline T ValueFromJSONKeyString( const std::string_view& aJSONString, const std::string_view aKeyName );
 
 /**
  * @brief Helper function to add a jsonable object to a JSON object.
@@ -216,16 +208,10 @@ inline T ValueFromJSONString( const std::string_view& aJSONString )
 	return ValueFromJSON<T>( nlohmann::json::parse( aJSONString ) );
 }
 
-template<is_json_constructible T>
+template<typename T>
 inline T ValueFromJSONKeyString( const std::string_view& aJSONString, const std::string_view aKeyName, auto&&... aArgs )
 {
-	return ValueFromRequiredJSONKey<T>( nlohmann::json::parse( aJSONString ), std::forward<decltype( aArgs )>( aArgs )..., aKeyName );
-}
-
-template<is_not_json_constructible T>
-inline T ValueFromJSONKeyString( const std::string_view& aJSONString, const std::string_view aKeyName )
-{
-	return ValueFromRequiredJSONKey<T>( nlohmann::json::parse( aJSONString ), aKeyName );
+	return ValueFromRequiredJSONKey<T>( nlohmann::json::parse( aJSONString ), aKeyName, std::forward<decltype( aArgs )>( aArgs )... );
 }
 
 inline void AddToJSON( is_json_type auto& aJSON, const is_jsonable auto& aObject, auto&&... aArgs ) noexcept

--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -70,19 +70,12 @@ template<is_not_json_constructible T>
 inline T ValueFromOptionalJSONKey( const is_json_type auto& aJSON, const std::string_view aKeyName, const T& aDefaultValue = T{} );
 
 /**
- * @brief Helper function to construct a jsonable class from a JSON string.
+ * @brief Helper function to construct a class from a JSON string.
  * @param aJSONString JSON string.
  * @param aArgs Extra arguments to be forwarded to the JSON constructor.
 */
-template<is_json_constructible T>
+template<typename T>
 inline T ValueFromJSONString( const std::string_view& aJSONString, auto&&... aArgs );
-
-/**
- * @brief Helper function to construct a non-jsonable type from a JSON string.
- * @param aJSONString JSON string.
-*/
-template<is_not_json_constructible T>
-inline T ValueFromJSONString( const std::string_view& aJSONString );
 
 /**
  * @brief Helper function to construct a class from a key in a JSON string.
@@ -196,16 +189,10 @@ inline T ValueFromOptionalJSONKey( const is_json_type auto& aJSON, const std::st
 	return found != aJSON.cend() ? ValueFromJSON<T>( *found ) : aDefaultValue;
 }
 
-template<is_json_constructible T>
+template<typename T>
 inline T ValueFromJSONString( const std::string_view& aJSONString, auto&&... aArgs )
 {
 	return ValueFromJSON<T>( nlohmann::json::parse( aJSONString ), std::forward<decltype( aArgs )>( aArgs )... );
-}
-
-template<is_not_json_constructible T>
-inline T ValueFromJSONString( const std::string_view& aJSONString )
-{
-	return ValueFromJSON<T>( nlohmann::json::parse( aJSONString ) );
 }
 
 template<typename T>

--- a/include/JsonUtils.h
+++ b/include/JsonUtils.h
@@ -42,21 +42,13 @@ template<is_not_json_constructible T>
 inline T ValueFromJSON( const is_json_type auto& aJSON );
 
 /**
- * @brief Helper function to construct a jsonable class under a key in a JSON object.
+ * @brief Helper function to construct a class under a key in a JSON object.
  * @param aJSON JSON object.
  * @param aArgs Extra arguments to be forwarded to the JSON constructor.
  * @param aKeyName Name of the key to search.
 */
-template<is_json_constructible T>
+template<typename T>
 inline T ValueFromRequiredJSONKey( const is_json_type auto& aJSON, const std::string_view aKeyName = json_traits<T>::KEY, auto&&... aArgs );
-
-/**
- * @brief Helper function to construct a non-jsonable type under a key in a JSON object.
- * @param aJSON JSON object.
- * @param aKeyName Name of the key to search.
-*/
-template<is_not_json_constructible T>
-inline T ValueFromRequiredJSONKey( const is_json_type auto& aJSON, const std::string_view aKeyName );
 
 /**
  * @brief Helper function to construct a jsonable class under an optional key in a JSON object.
@@ -192,16 +184,10 @@ inline T ValueFromJSON( const is_json_type auto& aJSON )
 	return aJSON.template get<T>();
 }
 
-template<is_json_constructible T>
+template<typename T>
 inline T ValueFromRequiredJSONKey( const is_json_type auto& aJSON, const std::string_view aKeyName, auto&&... aArgs )
 {
 	return ValueFromJSON<T>( aJSON.at( aKeyName ), std::forward<decltype( aArgs )>( aArgs )... );
-}
-
-template<is_not_json_constructible T>
-inline T ValueFromRequiredJSONKey( const is_json_type auto& aJSON, const std::string_view aKeyName )
-{
-	return ValueFromJSON<T>( aJSON.at( aKeyName ) );
 }
 
 template<is_json_constructible T>

--- a/src/CPerson.cpp
+++ b/src/CPerson.cpp
@@ -37,8 +37,7 @@ void CPerson::JSON( json& aJSON ) const noexcept
 {
 	AddToJSONKey( aJSON, mFirstName, FIRST_NAME_KEY );
 	AddToJSONKey( aJSON, mSurnames, SURNAMES_KEY );
-	if( mKnownName != mSurnames )
-		AddToJSONKey( aJSON, mKnownName, KNOWN_NAME_KEY );
+	AddToOptionalJSONKey( aJSON, mKnownName, KNOWN_NAME_KEY, mSurnames );
 	AddToJSONKey( aJSON, mAge, AGE_KEY );
 	AddToJSONKey( aJSON, mNationality, NATIONALITY_KEY );
 }

--- a/src/football/CExtraTime.cpp
+++ b/src/football/CExtraTime.cpp
@@ -30,8 +30,7 @@ FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the f
 void CExtraTime::JSON( json& aJSON ) const noexcept
 {
 	CPlayTime::JSON( aJSON );
-	if( mGoalRule != GOAL_RULE )
-		AddToJSONKey( aJSON, mGoalRule, GOAL_RULE_KEY );
+	AddToOptionalJSONKey( aJSON, mGoalRule, GOAL_RULE_KEY, GOAL_RULE );
 }
 
 const E_GOAL_RULE& CExtraTime::GetGoalRule() const noexcept


### PR DESCRIPTION
Allows to specify a value to ignore, in which case the object is not added to the JSON object.

Also unifies some function specializations which didn't need to be specialized