### PR TITLE
Create player state

### DIFF
--- a/FileList.cmake
+++ b/FileList.cmake
@@ -47,6 +47,7 @@ SET(FUTSIM_FOOTBALL_EXTERNAL_HEADERS
 	include/football/CPeriodStates.h
 	include/football/CPlayer.h
 	include/football/CPlayerSkills.h
+	include/football/CPlayerState.h
 	include/football/CPlayState.h
 	include/football/CPlayTime.h
 	include/football/CPossessionDrawConfiguration.h
@@ -151,6 +152,7 @@ SET(FUTSIM_FOOTBALL_SOURCE
 	src/football/CPeriodState.cpp
 	src/football/CPeriodStates.cpp
 	src/football/CPlayerSkills.cpp
+	src/football/CPlayerState.cpp
 	src/football/CPlayer.cpp
 	src/football/CPlayState.cpp
 	src/football/CPlayTime.cpp

--- a/FileList.cmake
+++ b/FileList.cmake
@@ -108,6 +108,7 @@ SET(FUTSIM_FOOTBALL_EXTERNAL_HEADERS
 	include/football/types/CPeriodState.h
 	include/football/types/CPeriodStates.h
 	include/football/types/CPlayerSkills.h
+	include/football/types/CPlayerState.h
 	include/football/types/CPlayState.h
 	include/football/types/CPlayTime.h
 	include/football/types/CPossessionDrawConfiguration.h

--- a/FileList.cmake
+++ b/FileList.cmake
@@ -84,6 +84,7 @@ SET(FUTSIM_FOOTBALL_EXTERNAL_HEADERS
 	include/football/traits/CPeriodStates.h
 	include/football/traits/CPlayer.h
 	include/football/traits/CPlayerSkills.h
+	include/football/traits/CPlayerState.h
 	include/football/traits/CPlayState.h
 	include/football/traits/CPlayTime.h
 	include/football/traits/CPossessionDrawConfiguration.h

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -22,6 +22,17 @@ protected:
 	void JSON( json& aJSON ) const noexcept override;
 
 public:
+	/**
+	 * @brief Addition operators.
+	 * @param aOther Other state to add to this one.
+	 * @{
+	 */
+	CPlayerState operator+( const CPlayerState& aOther ) const noexcept;
+	CPlayerState& operator+=( const CPlayerState& aOther ) noexcept;
+	/**
+	 * @}
+	 */
+
 	//! Retrieves the \copybrief mMinutesPlayed
 	const counter& GetMinutesPlayed() const noexcept;
 

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -2,6 +2,8 @@
 
 #include "IJsonable.h"
 
+#include "football/types/CPlayerState.h"
+
 namespace futsim::football
 {
 
@@ -10,6 +12,61 @@ namespace futsim::football
 */
 class CPlayerState : public IJsonable
 {
+protected:
+	using counter = types::CPlayerState::counter;
+
+public:
+	//! Retrieves the \copybrief mMinutesPlayed
+	const counter& GetMinutesPlayed() const noexcept;
+
+	//! Retrieves the \copybrief mSaves
+	const counter& GetSaves() const noexcept;
+
+	//! Retrieves the \copybrief mTackles
+	const counter& GetTackles() const noexcept;
+
+	//! Retrieves the \copybrief mPasses
+	const counter& GetPasses() const noexcept;
+
+	//! Retrieves the \copybrief mShots
+	const counter& GetShots() const noexcept;
+
+	//! Retrieves the \copybrief mAssists
+	const counter& GetAssists() const noexcept;
+
+	//! Retrieves the \copybrief mGoals
+	const counter& GetGoals() const noexcept;
+
+	//! Retrieves the \copybrief mFoulsCommitted
+	const counter& GetFoulsCommitted() const noexcept;
+
+	//! Retrieves the \copybrief mYellowCards
+	const counter& GetYellowCards() const noexcept;
+
+	//! Retrieves the \copybrief mRedCards
+	const counter& GetRedCards() const noexcept;
+
+private:
+	//! Minutes played.
+	counter mMinutesPlayed = 0;
+	//! Saves made.
+	counter mSaves = 0;
+	//! Tackles made.
+	counter mTackles = 0;
+	//! Passes made.
+	counter mPasses = 0;
+	//! Shots made.
+	counter mShots = 0;
+	//! Assists made.
+	counter mAssists = 0;
+	//! Goals scored.
+	counter mGoals = 0;
+	//! Fouls committed.
+	counter mFoulsCommitted = 0;
+	//! Yellow cards received.
+	counter mYellowCards = 0;
+	//! Red cards received.
+	counter mRedCards = 0;
 };
 
 } // futsim::football namespace

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -3,6 +3,7 @@
 #include "IJsonable.h"
 
 #include "football/types/CPlayerState.h"
+#include "football/traits/CPlayerState.h"
 
 namespace futsim::football
 {
@@ -10,10 +11,15 @@ namespace futsim::football
 /**
  * @brief Class encapsulating the state of a football player.
 */
-class CPlayerState : public IJsonable
+class CPlayerState : public IJsonable, protected json_traits<football::CPlayerState>
 {
 protected:
 	using counter = types::CPlayerState::counter;
+
+	/**
+	 * @copydoc IJsonable::ToJSON
+	*/
+	void JSON( json& aJSON ) const noexcept override;
 
 public:
 	//! Retrieves the \copybrief mMinutesPlayed

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -22,6 +22,12 @@ public:
 	//! Default constructor.
 	explicit CPlayerState() = default;
 
+	/**
+	 * @brief JSON constructor.
+	 * @param aJSON JSON object.
+	*/
+	explicit CPlayerState( const json& aJSON );	
+
 protected:
 	/**
 	 * @copydoc IJsonable::ToJSON

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -36,6 +36,11 @@ protected:
 
 public:
 	/**
+	 * @brief Indicates if the player has played
+	 */
+	explicit operator bool() const noexcept;
+
+	/**
 	 * @brief Addition operators.
 	 * @param aOther Other state to add to this one.
 	 * @{

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -63,6 +63,9 @@ public:
 	//! Retrieves the \copybrief mRedCards
 	const counter& GetRedCards() const noexcept;
 
+	//! Adds a minute of play.
+	void AddMinutePlayed() noexcept;
+
 private:
 	//! Minutes played.
 	counter mMinutesPlayed = 0;

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -74,6 +74,9 @@ public:
 	 */
 	void AddFoul( const CFoulState& aFoulState ) noexcept;
 
+	//! Adds a save.
+	void AddSave() noexcept;
+
 private:
 	//! Minutes played.
 	counter mMinutesPlayed = 0;

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -77,6 +77,9 @@ public:
 	//! Adds a save.
 	void AddSave() noexcept;
 
+	//! Adds a tackle.
+	void AddTackle() noexcept;
+
 private:
 	//! Minutes played.
 	counter mMinutesPlayed = 0;

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -86,6 +86,12 @@ public:
 	 */
 	void AddPass( bool aIsAssist ) noexcept;
 
+	/**
+	 * @brief Adds a shot.
+	 * @param aIsGoal If the shot is a goal.
+	 */
+	void AddShot( bool aIsGoal ) noexcept;
+
 private:
 	//! Minutes played.
 	counter mMinutesPlayed = 0;

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -18,6 +18,11 @@ class CPlayerState : public IJsonable, protected json_traits<football::CPlayerSt
 protected:
 	using counter = types::CPlayerState::counter;
 
+public:
+	//! Default constructor.
+	explicit CPlayerState() = default;
+
+protected:
 	/**
 	 * @copydoc IJsonable::ToJSON
 	*/

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "IJsonable.h"
+
+namespace futsim::football
+{
+
+/**
+ * @brief Class encapsulating the state of a football player.
+*/
+class CPlayerState : public IJsonable
+{
+};
+
+} // futsim::football namespace

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -8,6 +8,8 @@
 namespace futsim::football
 {
 
+class CFoulState;
+
 /**
  * @brief Class encapsulating the state of a football player.
 */
@@ -65,6 +67,12 @@ public:
 
 	//! Adds a minute of play.
 	void AddMinutePlayed() noexcept;
+
+	/**
+	 * @brief Adds a foul.
+	 * @param aFoulState State of the foul to be added.
+	 */
+	void AddFoul( const CFoulState& aFoulState ) noexcept;
 
 private:
 	//! Minutes played.

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -80,6 +80,12 @@ public:
 	//! Adds a tackle.
 	void AddTackle() noexcept;
 
+	/**
+	 * @brief Adds a pass.
+	 * @param aIsAssist If the pass is an assist.
+	 */
+	void AddPass( bool aIsAssist ) noexcept;
+
 private:
 	//! Minutes played.
 	counter mMinutesPlayed = 0;

--- a/include/football/CPlayerState.h
+++ b/include/football/CPlayerState.h
@@ -76,32 +76,41 @@ public:
 	//! Retrieves the \copybrief mRedCards
 	const counter& GetRedCards() const noexcept;
 
-	//! Adds a minute of play.
-	void AddMinutePlayed() noexcept;
+	/**
+	 * @brief Adds a minute of play.
+	 * @return The object itself.
+	 */
+	CPlayerState& AddMinutePlayed() noexcept;
 
 	/**
 	 * @brief Adds a foul.
 	 * @param aFoulState State of the foul to be added.
 	 */
-	void AddFoul( const CFoulState& aFoulState ) noexcept;
+	CPlayerState& AddFoul( const CFoulState& aFoulState ) noexcept;
 
-	//! Adds a save.
-	void AddSave() noexcept;
+	/**
+	 * @brief Adds a save.
+	 * @return The object itself.
+	 */
+	CPlayerState& AddSave() noexcept;
 
-	//! Adds a tackle.
-	void AddTackle() noexcept;
+	/**
+	 * @brief Adds a tackle.
+	 * @return The object itself.
+	 */
+	CPlayerState& AddTackle() noexcept;
 
 	/**
 	 * @brief Adds a pass.
 	 * @param aIsAssist If the pass is an assist.
 	 */
-	void AddPass( bool aIsAssist ) noexcept;
+	CPlayerState& AddPass( bool aIsAssist ) noexcept;
 
 	/**
 	 * @brief Adds a shot.
 	 * @param aIsGoal If the shot is a goal.
 	 */
-	void AddShot( bool aIsGoal ) noexcept;
+	CPlayerState& AddShot( bool aIsGoal ) noexcept;
 
 private:
 	//! Minutes played.

--- a/include/football/traits/CPlayerState.h
+++ b/include/football/traits/CPlayerState.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "traits/json.h"
+
+#include <string_view>
+
+namespace futsim
+{
+
+namespace football
+{
+class CPlayerState;
+}
+
+template <> struct json_traits<football::CPlayerState>
+{
+	//! JSON key for the class.
+	static inline constexpr std::string_view KEY = "Player state";
+	//! JSON key for the \copybrief football::CPlayerState::mMinutesPlayed
+	static inline constexpr std::string_view MINUTES_PLAYED_KEY = "Minutes played";
+	//! JSON key for the \copybrief football::CPlayerState::mSaves
+	static inline constexpr std::string_view SAVES_KEY = "Saves";
+	//! JSON key for the \copybrief football::CPlayerState::mTackles
+	static inline constexpr std::string_view TACKLES_KEY = "Tackles";
+	//! JSON key for the \copybrief football::CPlayerState::mPasses
+	static inline constexpr std::string_view PASSES_KEY = "Passes";
+	//! JSON key for the \copybrief football::CPlayerState::mShots
+	static inline constexpr std::string_view SHOTS_KEY = "Shots";
+	//! JSON key for the \copybrief football::CPlayerState::mAssists
+	static inline constexpr std::string_view ASSISTS_KEY = "Assists";
+	//! JSON key for the \copybrief football::CPlayerState::mGoals
+	static inline constexpr std::string_view GOALS_KEY = "Goals";
+	//! JSON key for the \copybrief football::CPlayerState::mFoulsCommitted
+	static inline constexpr std::string_view FOULS_COMMITTED = "Fouls committed";
+	//! JSON key for the \copybrief football::CPlayerState::mYellowCards
+	static inline constexpr std::string_view YELLOW_CARDS_KEY = "Yellow cards";
+	//! JSON key for the \copybrief football::CPlayerState::mRedCards
+	static inline constexpr std::string_view RED_CARDS_KEY = "Red cards";
+};
+
+} // futsim namespace

--- a/include/football/types/CPlayerState.h
+++ b/include/football/types/CPlayerState.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace futsim::football::types::CPlayerState
+{
+
+//! Type for a counter.
+using counter = unsigned int;
+
+} // futsim::football::types::CPlayerState namespace

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -131,4 +131,11 @@ void CPlayerState::AddPass( bool aIsAssist ) noexcept
 		++mAssists;
 }
 
+void CPlayerState::AddShot( bool aIsGoal ) noexcept
+{
+	++mShots;
+	if( aIsGoal )
+		++mGoals;
+}
+
 } // futsim::football namespace

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -124,4 +124,11 @@ void CPlayerState::AddTackle() noexcept
 	++mTackles;
 }
 
+void CPlayerState::AddPass( bool aIsAssist ) noexcept
+{
+	++mPasses;
+	if( aIsAssist )
+		++mAssists;
+}
+
 } // futsim::football namespace

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -119,4 +119,9 @@ void CPlayerState::AddSave() noexcept
 	++mSaves;
 }
 
+void CPlayerState::AddTackle() noexcept
+{
+	++mTackles;
+}
+
 } // futsim::football namespace

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -1,0 +1,56 @@
+#include "football/CPlayerState.h"
+
+namespace futsim::football
+{
+
+const CPlayerState::counter& CPlayerState::GetMinutesPlayed() const noexcept
+{
+	return mMinutesPlayed;
+}
+
+const CPlayerState::counter& CPlayerState::GetSaves() const noexcept
+{
+	return mSaves;
+}
+
+const CPlayerState::counter& CPlayerState::GetTackles() const noexcept
+{
+	return mTackles;
+}
+
+const CPlayerState::counter& CPlayerState::GetPasses() const noexcept
+{
+	return mPasses;
+}
+
+const CPlayerState::counter& CPlayerState::GetShots() const noexcept
+{
+	return mShots;
+}
+
+const CPlayerState::counter& CPlayerState::GetAssists() const noexcept
+{
+	return mAssists;
+}
+
+const CPlayerState::counter& CPlayerState::GetGoals() const noexcept
+{
+	return mGoals;
+}
+
+const CPlayerState::counter& CPlayerState::GetFoulsCommitted() const noexcept
+{
+	return mFoulsCommitted;
+}
+
+const CPlayerState::counter& CPlayerState::GetYellowCards() const noexcept
+{
+	return mYellowCards;
+}
+
+const CPlayerState::counter& CPlayerState::GetRedCards() const noexcept
+{
+	return mRedCards;
+}
+
+} // futsim::football namespace

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -37,6 +37,11 @@ void CPlayerState::JSON( json& aJSON ) const noexcept
 	AddToOptionalJSONKey( aJSON, mRedCards, RED_CARDS_KEY );
 }
 
+CPlayerState::operator bool() const noexcept
+{
+	return mMinutesPlayed != 0;
+}
+
 CPlayerState CPlayerState::operator+( const CPlayerState& aOther ) const noexcept
 {
 	return CPlayerState{ *this } += aOther;

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -19,6 +19,27 @@ void CPlayerState::JSON( json& aJSON ) const noexcept
 	AddToOptionalJSONKey( aJSON, mRedCards, RED_CARDS_KEY );
 }
 
+CPlayerState CPlayerState::operator+( const CPlayerState& aOther ) const noexcept
+{
+	return CPlayerState{ *this } += aOther;
+}
+
+CPlayerState& CPlayerState::operator+=( const CPlayerState& aOther ) noexcept
+{
+	mMinutesPlayed += aOther.mMinutesPlayed;
+	mSaves += aOther.mSaves;
+	mTackles += aOther.mTackles;
+	mPasses += aOther.mPasses;
+	mShots += aOther.mShots;
+	mAssists += aOther.mAssists;
+	mGoals += aOther.mGoals;
+	mFoulsCommitted += aOther.mFoulsCommitted;
+	mYellowCards += aOther.mYellowCards;
+	mRedCards += aOther.mRedCards;
+	
+	return *this;
+}
+
 const CPlayerState::counter& CPlayerState::GetMinutesPlayed() const noexcept
 {
 	return mMinutesPlayed;

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -2,10 +2,26 @@
 
 #include "football/CFoulState.h"
 
+#include "ExceptionUtils.h"
 #include "JsonUtils.h"
 
 namespace futsim::football
 {
+
+CPlayerState::CPlayerState( const json& aJSON ) try :
+	mMinutesPlayed( ValueFromOptionalJSONKey<counter>( aJSON, MINUTES_PLAYED_KEY ) ),
+	mSaves( ValueFromOptionalJSONKey<counter>( aJSON, SAVES_KEY ) ),
+	mTackles( ValueFromOptionalJSONKey<counter>( aJSON, TACKLES_KEY ) ),
+	mPasses( ValueFromOptionalJSONKey<counter>( aJSON, PASSES_KEY ) ),
+	mShots( ValueFromOptionalJSONKey<counter>( aJSON, SHOTS_KEY ) ),
+	mAssists( ValueFromOptionalJSONKey<counter>( aJSON, ASSISTS_KEY ) ),
+	mGoals( ValueFromOptionalJSONKey<counter>( aJSON, GOALS_KEY ) ),
+	mFoulsCommitted( ValueFromOptionalJSONKey<counter>( aJSON, FOULS_COMMITTED ) ),
+	mYellowCards( ValueFromOptionalJSONKey<counter>( aJSON, YELLOW_CARDS_KEY ) ),
+	mRedCards( ValueFromOptionalJSONKey<counter>( aJSON, RED_CARDS_KEY ) )
+{
+}
+FUTSIM_CATCH_AND_RETHROW_EXCEPTION( std::invalid_argument, "Error creating the player state from JSON." )
 
 void CPlayerState::JSON( json& aJSON ) const noexcept
 {

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -114,4 +114,9 @@ void CPlayerState::AddFoul( const CFoulState& aFoulState ) noexcept
 	}
 }
 
+void CPlayerState::AddSave() noexcept
+{
+	++mSaves;
+}
+
 } // futsim::football namespace

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -90,4 +90,9 @@ const CPlayerState::counter& CPlayerState::GetRedCards() const noexcept
 	return mRedCards;
 }
 
+void CPlayerState::AddMinutePlayed() noexcept
+{
+	++mMinutesPlayed;
+}
+
 } // futsim::football namespace

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -1,5 +1,7 @@
 #include "football/CPlayerState.h"
 
+#include "football/CFoulState.h"
+
 #include "JsonUtils.h"
 
 namespace futsim::football
@@ -93,6 +95,23 @@ const CPlayerState::counter& CPlayerState::GetRedCards() const noexcept
 void CPlayerState::AddMinutePlayed() noexcept
 {
 	++mMinutesPlayed;
+}
+
+void CPlayerState::AddFoul( const CFoulState& aFoulState ) noexcept
+{
+	using types::CFoulDrawConfiguration::E_FOUL_DRAW_OUTCOME;
+	++mFoulsCommitted;
+	switch( aFoulState.GetOutcome() )
+	{
+	case E_FOUL_DRAW_OUTCOME::YELLOW_CARD :
+		++mYellowCards;
+		break;
+	case E_FOUL_DRAW_OUTCOME::RED_CARD :
+		++mRedCards;
+		break;
+	case E_FOUL_DRAW_OUTCOME::NO_CARD: default :
+		break;
+	}
 }
 
 } // futsim::football namespace

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -1,7 +1,23 @@
 #include "football/CPlayerState.h"
 
+#include "JsonUtils.h"
+
 namespace futsim::football
 {
+
+void CPlayerState::JSON( json& aJSON ) const noexcept
+{
+	AddToOptionalJSONKey( aJSON, mMinutesPlayed, MINUTES_PLAYED_KEY );
+	AddToOptionalJSONKey( aJSON, mSaves, SAVES_KEY );
+	AddToOptionalJSONKey( aJSON, mTackles, TACKLES_KEY );
+	AddToOptionalJSONKey( aJSON, mPasses, PASSES_KEY );
+	AddToOptionalJSONKey( aJSON, mShots, SHOTS_KEY );
+	AddToOptionalJSONKey( aJSON, mAssists, ASSISTS_KEY );
+	AddToOptionalJSONKey( aJSON, mGoals, GOALS_KEY );
+	AddToOptionalJSONKey( aJSON, mFoulsCommitted, FOULS_COMMITTED );
+	AddToOptionalJSONKey( aJSON, mYellowCards, YELLOW_CARDS_KEY );
+	AddToOptionalJSONKey( aJSON, mRedCards, RED_CARDS_KEY );
+}
 
 const CPlayerState::counter& CPlayerState::GetMinutesPlayed() const noexcept
 {

--- a/src/football/CPlayerState.cpp
+++ b/src/football/CPlayerState.cpp
@@ -108,12 +108,13 @@ const CPlayerState::counter& CPlayerState::GetRedCards() const noexcept
 	return mRedCards;
 }
 
-void CPlayerState::AddMinutePlayed() noexcept
+CPlayerState& CPlayerState::AddMinutePlayed() noexcept
 {
 	++mMinutesPlayed;
+	return *this;
 }
 
-void CPlayerState::AddFoul( const CFoulState& aFoulState ) noexcept
+CPlayerState& CPlayerState::AddFoul( const CFoulState& aFoulState ) noexcept
 {
 	using types::CFoulDrawConfiguration::E_FOUL_DRAW_OUTCOME;
 	++mFoulsCommitted;
@@ -121,37 +122,41 @@ void CPlayerState::AddFoul( const CFoulState& aFoulState ) noexcept
 	{
 	case E_FOUL_DRAW_OUTCOME::YELLOW_CARD :
 		++mYellowCards;
-		break;
+		return *this;
 	case E_FOUL_DRAW_OUTCOME::RED_CARD :
 		++mRedCards;
-		break;
+		return *this;
 	case E_FOUL_DRAW_OUTCOME::NO_CARD: default :
-		break;
+		return *this;
 	}
 }
 
-void CPlayerState::AddSave() noexcept
+CPlayerState& CPlayerState::AddSave() noexcept
 {
 	++mSaves;
+	return *this;
 }
 
-void CPlayerState::AddTackle() noexcept
+CPlayerState& CPlayerState::AddTackle() noexcept
 {
 	++mTackles;
+	return *this;
 }
 
-void CPlayerState::AddPass( bool aIsAssist ) noexcept
+CPlayerState& CPlayerState::AddPass( bool aIsAssist ) noexcept
 {
 	++mPasses;
 	if( aIsAssist )
 		++mAssists;
+	return *this;
 }
 
-void CPlayerState::AddShot( bool aIsGoal ) noexcept
+CPlayerState& CPlayerState::AddShot( bool aIsGoal ) noexcept
 {
 	++mShots;
 	if( aIsGoal )
 		++mGoals;
+	return *this;
 }
 
 } // futsim::football namespace

--- a/tests/FileList.cmake
+++ b/tests/FileList.cmake
@@ -28,6 +28,7 @@ SET(FUTSIM_TESTS_UNIT_FOOTBALL_SOURCE
 	unit/football/TPeriodStates.cpp
 	unit/football/TPlayer.cpp
 	unit/football/TPlayerSkills.cpp
+	unit/football/TPlayerState.cpp
 	unit/football/TPlayState.cpp
 	unit/football/TPlayTime.cpp
 	unit/football/TPossessionDrawConfiguration.cpp

--- a/tests/unit/football/TPlayerState.cpp
+++ b/tests/unit/football/TPlayerState.cpp
@@ -2,6 +2,8 @@
 
 #include "football/CPlayerState.h"
 
+#include "football/CFoulState.h"
+
 #include "JsonUtils.h"
 
 #include <iostream>
@@ -18,10 +20,132 @@ void TPlayerState::TestExceptions() const
 std::vector<std::string> TPlayerState::ObtainedResults() const noexcept
 {
 	std::vector<std::string> result;
+
+	std::mt19937 rng{ 1234 };
+
+	const auto state = CPlayerState{}.AddMinutePlayed().AddMinutePlayed().AddMinutePlayed().AddMinutePlayed().AddMinutePlayed()
+			.AddFoul( CFoulState{ CMatchConfiguration{}, CTeamStrategy{ "A", CLineup{ "Ter Stegen", {}, {}, {}, {}, {}, {} } }, rng } )
+			.AddFoul( CFoulState{ CMatchConfiguration{}, CTeamStrategy{ "A", CLineup{ "Iñaki Peña", {}, {}, {}, {}, {}, {} } }, rng } )
+			.AddPass( true ).AddPass( false ).AddSave().AddSave().AddSave().AddShot( false ).AddShot( true ).AddShot( true )
+			.AddTackle().AddTackle().AddTackle();
+
+	const auto JSONstate = futsim::ValueFromJSONKeyString<CPlayerState>( R"( {
+		"Player state": {
+			"Minutes played": 5,
+			"Saves": 3,
+			"Tackles": 3,
+			"Passes": 2,
+			"Shots": 3,
+			"Assists": 1,
+			"Goals": 2,
+			"Fouls committed": 2
+		}
+	} )" );
+
+	for( const auto& playerState : {
+			CPlayerState{},
+			CPlayerState{} + CPlayerState{},
+			state,
+			state + state,
+			futsim::ValueFromJSONKeyString<CPlayerState>( R"( { "Player state": null } )" ),
+			futsim::ValueFromJSONKeyString<CPlayerState>( R"( { "Player state": null } )" ),
+			JSONstate,
+			JSONstate + JSONstate,
+	} )
+	{
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::MINUTES_PLAYED_KEY } + ": " + std::to_string( playerState.GetMinutesPlayed() ) );
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::SAVES_KEY } + ": " + std::to_string( playerState.GetSaves() ) );
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::TACKLES_KEY } + ": " + std::to_string( playerState.GetTackles() ) );
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::PASSES_KEY } + ": " + std::to_string( playerState.GetPasses() ) );
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::SHOTS_KEY } + ": " + std::to_string( playerState.GetShots() ) );
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::ASSISTS_KEY } + ": " + std::to_string( playerState.GetAssists() ) );
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::GOALS_KEY } + ": " + std::to_string( playerState.GetGoals() ) );
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::FOULS_COMMITTED } + ": " + std::to_string( playerState.GetFoulsCommitted() ) );
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::YELLOW_CARDS_KEY } + ": " + std::to_string( playerState.GetYellowCards() ) );	
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::RED_CARDS_KEY } + ": " + std::to_string( playerState.GetRedCards() ) );	
+		futsim::types::IJsonable::json outputJSON;
+		AddToJSONKey( outputJSON, playerState );
+		result.push_back( outputJSON.dump( 1, '\t' ) );
+	}
+
 	return result;
 }
 
 std::vector<std::string> TPlayerState::ExpectedResults() const noexcept
 {
-	return std::vector<std::string>{};
+	std::vector<std::string> result{
+		"Minutes played: 0",
+		"Saves: 0",
+		"Tackles: 0",
+		"Passes: 0",
+		"Shots: 0",
+		"Assists: 0",
+		"Goals: 0",
+		"Fouls committed: 0",
+		"Yellow cards: 0",
+		"Red cards: 0",
+		"{\n"
+		"	\"Player state\": null\n"
+		"}",
+		"Minutes played: 0",
+		"Saves: 0",
+		"Tackles: 0",
+		"Passes: 0",
+		"Shots: 0",
+		"Assists: 0",
+		"Goals: 0",
+		"Fouls committed: 0",
+		"Yellow cards: 0",
+		"Red cards: 0",
+		"{\n"
+		"	\"Player state\": null\n"
+		"}",
+		"Minutes played: 5",
+		"Saves: 3",
+		"Tackles: 3",
+		"Passes: 2",
+		"Shots: 3",
+		"Assists: 1",
+		"Goals: 2",
+		"Fouls committed: 2",
+		"Yellow cards: 0",
+		"Red cards: 0",
+		"{\n"
+		"	\"Player state\": {\n"
+		"		\"Minutes played\": 5,\n"
+		"		\"Saves\": 3,\n"
+		"		\"Tackles\": 3,\n"
+		"		\"Passes\": 2,\n"
+		"		\"Shots\": 3,\n"
+		"		\"Assists\": 1,\n"
+		"		\"Goals\": 2,\n"
+		"		\"Fouls committed\": 2\n"
+		"	}\n"
+		"}",
+		"Minutes played: 10",
+		"Saves: 6",
+		"Tackles: 6",
+		"Passes: 4",
+		"Shots: 6",
+		"Assists: 2",
+		"Goals: 4",
+		"Fouls committed: 4",
+		"Yellow cards: 0",
+		"Red cards: 0",
+		"{\n"
+		"	\"Player state\": {\n"
+		"		\"Minutes played\": 10,\n"
+		"		\"Saves\": 6,\n"
+		"		\"Tackles\": 6,\n"
+		"		\"Passes\": 4,\n"
+		"		\"Shots\": 6,\n"
+		"		\"Assists\": 2,\n"
+		"		\"Goals\": 4,\n"
+		"		\"Fouls committed\": 4\n"
+		"	}\n"
+		"}"
+	};
+	result.reserve( 2 * result.size() );
+	result.insert( result.cend(), result.cbegin(), result.cend() );
+	return result;
 }

--- a/tests/unit/football/TPlayerState.cpp
+++ b/tests/unit/football/TPlayerState.cpp
@@ -61,11 +61,14 @@ std::vector<std::string> TPlayerState::ObtainedResults() const noexcept
 		result.push_back( std::string{ futsim::json_traits<CPlayerState>::ASSISTS_KEY } + ": " + std::to_string( playerState.GetAssists() ) );
 		result.push_back( std::string{ futsim::json_traits<CPlayerState>::GOALS_KEY } + ": " + std::to_string( playerState.GetGoals() ) );
 		result.push_back( std::string{ futsim::json_traits<CPlayerState>::FOULS_COMMITTED } + ": " + std::to_string( playerState.GetFoulsCommitted() ) );
-		result.push_back( std::string{ futsim::json_traits<CPlayerState>::YELLOW_CARDS_KEY } + ": " + std::to_string( playerState.GetYellowCards() ) );	
-		result.push_back( std::string{ futsim::json_traits<CPlayerState>::RED_CARDS_KEY } + ": " + std::to_string( playerState.GetRedCards() ) );	
-		futsim::types::IJsonable::json outputJSON;
-		AddToJSONKey( outputJSON, playerState );
-		result.push_back( outputJSON.dump( 1, '\t' ) );
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::YELLOW_CARDS_KEY } + ": " + std::to_string( playerState.GetYellowCards() ) );
+		result.push_back( std::string{ futsim::json_traits<CPlayerState>::RED_CARDS_KEY } + ": " + std::to_string( playerState.GetRedCards() ) );
+		if( playerState )
+		{
+			futsim::types::IJsonable::json outputJSON;
+			AddToJSONKey( outputJSON, playerState );
+			result.push_back( outputJSON.dump( 1, '\t' ) );
+		}
 	}
 
 	return result;
@@ -84,9 +87,6 @@ std::vector<std::string> TPlayerState::ExpectedResults() const noexcept
 		"Fouls committed: 0",
 		"Yellow cards: 0",
 		"Red cards: 0",
-		"{\n"
-		"	\"Player state\": null\n"
-		"}",
 		"Minutes played: 0",
 		"Saves: 0",
 		"Tackles: 0",
@@ -97,9 +97,6 @@ std::vector<std::string> TPlayerState::ExpectedResults() const noexcept
 		"Fouls committed: 0",
 		"Yellow cards: 0",
 		"Red cards: 0",
-		"{\n"
-		"	\"Player state\": null\n"
-		"}",
 		"Minutes played: 5",
 		"Saves: 3",
 		"Tackles: 3",

--- a/tests/unit/football/TPlayerState.cpp
+++ b/tests/unit/football/TPlayerState.cpp
@@ -1,0 +1,27 @@
+#include "ATest.h"
+
+#include "football/CPlayerState.h"
+
+#include "JsonUtils.h"
+
+#include <iostream>
+
+using namespace futsim::football;
+using namespace nlohmann;
+
+INITIALIZE_TEST( TPlayerState )
+
+void TPlayerState::TestExceptions() const
+{
+}
+
+std::vector<std::string> TPlayerState::ObtainedResults() const noexcept
+{
+	std::vector<std::string> result;
+	return result;
+}
+
+std::vector<std::string> TPlayerState::ExpectedResults() const noexcept
+{
+	return std::vector<std::string>{};
+}


### PR DESCRIPTION
Creates state for a single player. This state can be used both for the player stats during a match and during a season, career, etc.

It is designed to start at 0 and be modified, so it doesn't include a member constructor (although it can be constructed from JSON)