### PR TITLE
Fix docs deployment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,22 +134,22 @@ endforeach(FUTSIM_MODULE)
 # Set version file path
 set( VERSION_FILE ${FUTSIM_DIR}/VERSION )
 
-# Configure Config.h
-add_custom_target(Config ALL
-		COMMAND ${CMAKE_COMMAND} -D SRC=${FUTSIM_INCLUDE_DIR}/Config.h.in
-		-D DST=${FUTSIM_INCLUDE_DIR}/Config.h
-		-D VERSION_FILE=${VERSION_FILE}
-		-P ${FUTSIM_DIR}/GenerateVersionHeader.cmake
-		)
-add_dependencies(FutSim_CORE_Objects Config)
-
 # Print build version
 add_custom_target(PrintBuild ALL
 		COMMAND ${CMAKE_COMMAND} -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
 		-D VERSION_FILE=${VERSION_FILE}
 		-P ${FUTSIM_DIR}/PrintVersion.cmake
 		)
-add_dependencies(Config PrintBuild)
+
+# Configure Config.h
+add_custom_target(Config ALL
+		COMMAND ${CMAKE_COMMAND} -D SRC=${FUTSIM_INCLUDE_DIR}/Config.h.in
+		-D DST=${FUTSIM_INCLUDE_DIR}/Config.h
+		-D VERSION_FILE=${VERSION_FILE}
+		-P ${FUTSIM_DIR}/GenerateVersionHeader.cmake
+		DEPENDS PrintBuild
+		)
+add_dependencies(FutSim_CORE_Objects Config)
 
 # Build documentation
 if(BUILD_DOCUMENTATION)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -41,5 +41,6 @@ add_custom_target(Config_doc ALL
 		-D DOC_PATH=${CMAKE_CURRENT_SOURCE_DIR}
 		-D CONTENT_PATH=${CONTENT_PATH}
 		-P ${FUTSIM_DIR}/GenerateVersionHeader.cmake
+		DEPENDS PrintBuild
 		)
 add_dependencies(doc_doxygen Config_doc)


### PR DESCRIPTION
Configuration targets must depend on PrintBuild to guarantee that the VERSION file has been created