### PR TITLE
Retrieve history when deploying docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,6 +30,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+        fetch-depth: 0
     - name: Install dependencies
       run: |
        sudo apt-get install nlohmann-json3-dev graphviz doxygen ninja-build


### PR DESCRIPTION
The history is needed to configure the documentation with the proper build version.

Resolves #217 